### PR TITLE
Use default theme in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ ARG phpversion='8.3'
 FROM tripalproject/tripaldocker:drupal${drupalversion}-php${phpversion}-pgsql13-noChado
 
 ARG chadoschema='testchado'
-ARG sitename="Tripal Cultivate"
-
 WORKDIR /var/www/drupal/web/themes
 
 ## Download the Tripal Cultivate base theme
@@ -12,7 +10,9 @@ RUN git clone https://github.com/TripalCultivate/TripalCultivate-Theme.git trpcu
   && service postgresql restart \
   && drush theme:enable trpcultivatetheme --yes \
   && drush config-set system.theme default trpcultivatetheme \
-  && drush config:set system.site name "${sitename}" \
+  && export DRUPALVERSION=`drush core:status --field=drupal-version` \
+  && export PHPVERSION=`drush core:status --field=php-version` \
+  && drush config:set system.site name "Tripal Cultivate on D$DRUPALVERSION PHP$PHPVERSION" \
   && service postgresql stop
 
 COPY . /var/www/drupal/web/modules/contrib/TripalCultivate

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,24 @@ ARG phpversion='8.3'
 FROM tripalproject/tripaldocker:drupal${drupalversion}-php${phpversion}-pgsql13-noChado
 
 ARG chadoschema='testchado'
-COPY . /var/www/drupal/web/modules/contrib/TripalCultivate
+ARG sitename="Tripal Cultivate"
 
+WORKDIR /var/www/drupal/web/themes
+
+## Download the Tripal Cultivate base theme
+RUN git clone https://github.com/TripalCultivate/TripalCultivate-Theme.git trpcultivatetheme \
+  && service postgresql restart \
+  && drush theme:enable trpcultivatetheme --yes \
+  && drush config-set system.theme default trpcultivatetheme \
+  && drush config:set system.site name "${sitename}" \
+  && service postgresql stop
+
+COPY . /var/www/drupal/web/modules/contrib/TripalCultivate
 WORKDIR /var/www/drupal/web/modules/contrib/TripalCultivate
 
-RUN service postgresql restart \
+RUN service postgresql start \
   && drush trp-install-chado --schema-name=${chadoschema} \
   && drush trp-prep-chado --schema-name=${chadoschema} \
   && drush en trpcultivate --yes \
-  && drush cr
+  && drush cr \
+  && service postgresql stop


### PR DESCRIPTION
Issue #5 

This PR updates the dockerfile to use the [Tripal Cultivate theme](https://github.com/TripalCultivate/TripalCultivate-Theme) and update the site name to indicate we are developing Tripal Cultivate.

## Testing

1. Create a docker image and container from this branch
```
git clone https://github.com/TripalCultivate/TripalCultivate.git trpcultivate-5-usetheme
cd trpcultivate-5-usetheme
git checkout 5-use-default-theme-in-docker
docker build --tag=trpcultivate:5 --build-arg drupalversion=10.2.x-dev --build-arg phpversion=8.3 ./
docker run --publish=80:80 -tid --name=base5 --volume=`pwd`:/var/www/drupal/web/modules/contrib/TripalCultivate trpcultivate:5
docker exec base5 service postgresql restart
```
2. Open up the browse and confirm you see the green tripal cultivate theme and the Drupal and PHP versions are specified.
![image](https://github.com/TripalCultivate/TripalCultivate/assets/1566301/f197163e-5d39-411b-832d-5d110e2f702e)
