### PR TITLE
Use workflows to build docker images and schedule testing

### DIFF
--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -1,6 +1,17 @@
 
 name: PHPUnit
-on: [push, workflow_dispatch]
+on:
+  push:
+    branches-ignore:
+      - 4.x
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 2am every night.
+    - cron: '0 2 * * *'
 
 env:
   PKG_NAME: TripalCultivate

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       # Check out the repo
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Here we pull the development tripaldocker image for this combo in our matrix
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.3

--- a/.github/workflows/ALL-testCoverage-codeclimate.yml
+++ b/.github/workflows/ALL-testCoverage-codeclimate.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       # Check out the repo
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Here we fully  build a docker using the current checked out code
       # to ensure we have not broken the install/build process.
       - name: Build our docker image

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out code
-      - uses: mr-smithers-excellent/docker-build-push@v6
+      - uses: mr-smithers-excellent/docker-build-push@v6.3
         name: Build & push Full matrix of Docker images
         with:
           image: knowpulse/tripalcultivate
@@ -51,7 +51,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           buildArgs: "drupalversion=${{ matrix.drupal-version }},phpversion=${{ matrix.php-version }}"
           labels: 'drupal.version.label="${{ matrix.drupal-version }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
-      - uses: mr-smithers-excellent/docker-build-push@v6
+      - uses: mr-smithers-excellent/docker-build-push@v6.3
         name: Build baseonly-latest using 10.2.x-dev, PHP 8.3, PgSQL 13
         if: ${{ matrix.drupal-version == '10.2.x-dev' && matrix.php-version == '8.3' && matrix.pgsql-version == '13' }}
         with:

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -4,7 +4,14 @@ on:
     branches:
       - 4.x
       - G0.7-workflowBuildImages
+  # Allows us to manually trigger this workflow. 
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
   workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule: 
+    # Run at 2am every night.
+    - cron: '0 2 * * *'
 
 jobs:
   push_to_registry:
@@ -30,7 +37,7 @@ jobs:
           - php-version: "8.3"
             pgsql-version: "13"
             drupal-version: "10.1.x-dev"
-    name: Docker Build (drupal${{ matrix.drupal-version }})
+    name: Docker Build (baseonly-drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }})
     steps:
       - uses: actions/checkout@v3
         name: Check out code
@@ -45,11 +52,11 @@ jobs:
           buildArgs: "drupalversion=${{ matrix.drupal-version }},phpversion=${{ matrix.php-version }}"
           labels: 'drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v6
-        name: Build latest using 10.2.x-dev, PHP 8.3, PgSQL 13
+        name: Build baseonly-latest using 10.2.x-dev, PHP 8.3, PgSQL 13
         if: ${{ matrix.drupal-version == '10.2.x-dev' && matrix.php-version == '8.3' && matrix.pgsql-version == '13' }}
         with:
           image: knowpulse/tripalcultivate
-          tags: latest
+          tags: baseonly-latest
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -1,0 +1,56 @@
+name: Build and Publish Docker image
+on:
+  push:
+    branches:
+      - 4.x
+      - G0.7-workflowBuildImages
+
+jobs:
+  push_to_registry:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - "8.1"
+          - "8.2"
+          - "8.3"
+        pgsql-version:
+          - "13"
+        drupal-version:
+          - "10.0.x-dev"
+          - "10.1.x-dev"
+          - "10.2.x-dev"
+        exclude:
+          - php-version: "8.3"
+            pgsql-version: "13"
+            drupal-version: "10.0.x-dev"
+          - php-version: "8.3"
+            pgsql-version: "13"
+            drupal-version: "10.1.x-dev"
+    name: Docker Build (drupal${{ matrix.drupal-version }})
+    steps:
+      - uses: actions/checkout@v3
+        name: Check out code
+      - uses: mr-smithers-excellent/docker-build-push@v6
+        name: Build & push Full matrix of Docker images
+        with:
+          image: knowpulse/tripalcultivate
+          tags: baseonly-drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          buildArgs: "drupalversion=${{ matrix.drupal-version }},phpversion=${{ matrix.php-version }}"
+          labels: 'drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
+      - uses: mr-smithers-excellent/docker-build-push@v6
+        name: Build latest using 10.2.x-dev, PHP 8.3, PgSQL 13
+        if: ${{ matrix.drupal-version == '10.2.x-dev' && matrix.php-version == '8.3' && matrix.pgsql-version == '13' }}
+        with:
+          image: knowpulse/tripalcultivate
+          tags: latest
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          buildArgs: "drupalversion=${{ matrix.drupal-version }},phpversion=${{ matrix.php-version }}"
+          labels: 'drupal.version.label="${{ matrix.drupal-version }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - G0.7-workflowBuildImages
+  workflow_dispatch:
 
 jobs:
   push_to_registry:

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -39,7 +39,7 @@ jobs:
             drupal-version: "10.1.x-dev"
     name: Docker Build (baseonly-drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }})
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Check out code
       - uses: mr-smithers-excellent/docker-build-push@v6.3
         name: Build & push Full matrix of Docker images

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 4.x
+      - G0.7-workflowBuildImages
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -4,12 +4,12 @@ on:
     branches:
       - 4.x
       - G0.7-workflowBuildImages
-  # Allows us to manually trigger this workflow. 
+  # Allows us to manually trigger this workflow.
   # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
   workflow_dispatch:
   # Allows us to schedule when this workflow is run.
   # This ensures we pick up any new changes committed to Tripal Core.
-  schedule: 
+  schedule:
     # Run at 2am every night.
     - cron: '0 2 * * *'
 
@@ -50,7 +50,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           buildArgs: "drupalversion=${{ matrix.drupal-version }},phpversion=${{ matrix.php-version }}"
-          labels: 'drupal.version.label="${{ matrix.label }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
+          labels: 'drupal.version.label="${{ matrix.drupal-version }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v6
         name: Build baseonly-latest using 10.2.x-dev, PHP 8.3, PgSQL 13
         if: ${{ matrix.drupal-version == '10.2.x-dev' && matrix.php-version == '8.3' && matrix.pgsql-version == '13' }}

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -1,9 +1,16 @@
 name: PHPUnit
 on:
-  workflow_dispatch:
   push:
     branches:
       - 4.x
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 4am every morning.
+    - cron: '0 4 * * *'
 
 jobs:
   run-tests:

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.3
         with:

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -1,10 +1,17 @@
 name: PHPUnit
 on:
-  workflow_dispatch:
   push:
     branches:
       - 4.x
-      - customize-template
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 4am every morning.
+    - cron: '0 4 * * *'
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid1B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1B.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.3
         with:

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -1,10 +1,17 @@
 name: PHPUnit
 on:
-  workflow_dispatch:
   push:
     branches:
       - 4.x
-      - customize-template
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 4am every morning.
+    - cron: '0 4 * * *'
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.3
         with:

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -1,10 +1,17 @@
 name: PHPUnit
 on:
-  workflow_dispatch:
   push:
     branches:
       - 4.x
-      - customize-template
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 4am every morning.
+    - cron: '0 4 * * *'
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.3
         with:

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -1,10 +1,17 @@
 name: PHPUnit
 on:
-  workflow_dispatch:
   push:
     branches:
       - 4.x
-      - customize-template
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 4am every morning.
+    - cron: '0 4 * * *'
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.3
         with:

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -1,10 +1,17 @@
 name: PHPUnit
 on:
-  workflow_dispatch:
   push:
     branches:
       - 4.x
-      - customize-template
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 4am every morning.
+    - cron: '0 4 * * *'
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.3
         with:

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -1,10 +1,17 @@
 name: PHPUnit
 on:
-  workflow_dispatch:
   push:
     branches:
       - 4.x
-      - customize-template
+  # Allows us to manually trigger this workflow.
+  # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
+  workflow_dispatch:
+  # Allows us to schedule when this workflow is run.
+  # This ensures we pick up any new changes committed to Tripal Core.
+  schedule:
+    # Run at 4am every morning.
+    - cron: '0 4 * * *'
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Automated testing
         uses: tripal/test-tripal-action@v1.3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,10 @@ WORKDIR /var/www/drupal/web/modules/contrib/TripalCultivate
 RUN service postgresql start \
   && drush trp-install-chado --schema-name=${chadoschema} \
   && drush trp-prep-chado --schema-name=${chadoschema} \
+  && drush tripal:trp-import-types --username=drupaladmin --collection_id=general_chado \
+  && drush tripal:trp-import-types --username=drupaladmin --collection_id=germplasm_chado \
+  && drush tripal:trp-import-types --username=drupaladmin --collection_id=genomic_chado \
+  && drush tripal:trp-import-types --username=drupaladmin --collection_id=genetic_chado \
   && drush en trpcultivate --yes \
   && drush cr \
   && service postgresql stop


### PR DESCRIPTION
Issue #7 

This PR only touches the automated github workflows. Specifically,

- add a workflow to build docker images for the base TripalCultivate
- add scheduling to all workflows to ensure that we are always working with the most recent version of Tripal Core
- Add the ability to manually trigger all the workflows.
- Ensure that phpunit testing is not run 2X for all versions on the 4.x branch (previously was run by the MAIN-phpunit* workflows and the ALL-phpunit workflow.
- Import content types needed for the other packages.

## Testing

I'm not sure any testing is needed for this pr 🤔 

Maybe you could pull a couple of the images from dockerhub and run them to ensure they are the drupal/phpversion they say they are (login and go to http://localhost/admin/reports/status).

You could also do a quick code review if you want.