### PR TITLE
Add support for building base image without theme.

### DIFF
--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - G0.7-workflowBuildImages
+      - noTheme
   # Allows us to manually trigger this workflow.
   # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
   workflow_dispatch:
@@ -37,7 +37,7 @@ jobs:
           - php-version: "8.3"
             pgsql-version: "13"
             drupal-version: "10.1.x-dev"
-    name: Docker Build (baseonly-drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }})
+    name: Docker Build (${{ matrix.drupal-version }}, ${{ matrix.php-version }})
     steps:
       - uses: actions/checkout@v4
         name: Check out code
@@ -50,6 +50,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           buildArgs: "drupalversion=${{ matrix.drupal-version }},phpversion=${{ matrix.php-version }}"
+          labels: 'drupal.version.label="${{ matrix.drupal-version }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
+      - uses: mr-smithers-excellent/docker-build-push@v6.3
+        name: Build & push Full matrix of Docker images WITHOUT THEME
+        with:
+          image: knowpulse/tripalcultivate
+          tags: base-notheme-drupal${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          buildArgs: "drupalversion=${{ matrix.drupal-version }},phpversion=${{ matrix.php-version }},installTheme=FALSE"
           labels: 'drupal.version.label="${{ matrix.drupal-version }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v6.3
         name: Build baseonly-latest using 10.2.x-dev, PHP 8.3, PgSQL 13

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,15 @@ ARG phpversion='8.3'
 FROM tripalproject/tripaldocker:drupal${drupalversion}-php${phpversion}-pgsql13-noChado
 
 ARG chadoschema='testchado'
+ARG installTheme=TRUE
 WORKDIR /var/www/drupal/web/themes
 
 ## Download the Tripal Cultivate base theme
-RUN git clone https://github.com/TripalCultivate/TripalCultivate-Theme.git trpcultivatetheme \
-  && service postgresql restart \
+RUN service postgresql restart \
+  && if [ "$installTheme" = "TRUE" ]; then \
+  git clone https://github.com/TripalCultivate/TripalCultivate-Theme.git trpcultivatetheme \
   && drush theme:enable trpcultivatetheme --yes \
-  && drush config-set system.theme default trpcultivatetheme \
+  && drush config-set system.theme default trpcultivatetheme; fi \
   && export DRUPALVERSION=`drush core:status --field=drupal-version` \
   && export PHPVERSION=`drush core:status --field=php-version` \
   && drush config:set system.site name "Tripal Cultivate Docker" \


### PR DESCRIPTION
There is a bit of a circular dependancy going on between the base module and the theme with inclusion of the theme in the base docker image.

This PR fixes that by adding a build arguement to the dockerfile which allows us to specify building the base image without the theme. By default the theme is still included.

Additionally, the build docker workflow has been updated to create a `baseonly` and `base-notheme` docker image for each drupal/php/pgsql combination. This way we can use the `base-notheme` variant in the theme docker.

## Testing

I actually have the docker build workflow running on this branch. Thus to test, you can literally just pull some of the new images and create containers.

1. Pull a `baseonly-` image from dockerhub: `docker pull knowpulse/tripalcultivate:baseonly-drupal10.2.x-dev-php8.3-pgsql13`
2. Create a container for this image: `docker run --publish=80:80 -tid --name=baseonly knowpulse/tripalcultivate:baseonly-drupal10.2.x-dev-php8.3-pgsql13`
3. Confirm that the theme is applied when you go to the site. It should be green ;-)
4. Delete that container/image.
5. Pull a `base-notheme` image from dockerhub: `docker pull knowpulse/tripalcultivate:base-notheme-drupal10.2.x-dev-php8.3-pgsql13`
6. Create a container for this image: `docker run --publish=80:80 -tid --name=basenotheme knowpulse/tripalcultivate:base-notheme-drupal10.2.x-dev-php8.3-pgsql13`
7. Confirm that the default drupal theme is applied. It should be blue with a smaller header then before.