### PR TITLE
Update dockerfile to install companion module properly.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG drupalversion='10.2.x-dev'
 ARG phpversion='8.3'
-FROM tripalproject/tripaldocker:drupal${drupalversion}-php${phpversion}-pgsql13-noChado
+ARG postgresqlversion='16'
+FROM tripalproject/tripaldocker:drupal${drupalversion}-php${phpversion}-pgsql${postgresqlversion}-noChado
 
 ARG chadoschema='testchado'
 ARG installTheme=TRUE
@@ -10,6 +11,8 @@ WORKDIR /var/www/drupal/web/themes
 RUN service postgresql restart \
   && if [ "$installTheme" = "TRUE" ]; then \
   git clone https://github.com/TripalCultivate/TripalCultivate-Theme.git trpcultivatetheme \
+  && mv trpcultivatetheme/trpcultivatetheme_companion /var/www/drupal/web/modules/contrib/trpcultivatetheme_companion \
+  && drush pm:install trpcultivatetheme_companion --yes \
   && drush theme:enable trpcultivatetheme --yes \
   && drush config-set system.theme default trpcultivatetheme; fi \
   && export DRUPALVERSION=`drush core:status --field=drupal-version` \


### PR DESCRIPTION

Issue #14 

This PR makes a small change to the dockerfile to support the companion module to the theme as added in https://github.com/TripalCultivate/TripalCultivate-Theme/pull/14.

## Testing

1. Clone this repo and checkout this branch
2. Build a new image from this code: `docker build --tag=trpcultivate:14 --build-arg drupalversion=10.2.x-dev --build-arg phpversion=8.3 ./`
3. Run a new container (no need to mount when confirming functionality; for instructions on mounting see the README): `docker run --publish=80:80 -tid --name=base14 trpcultivate:11 && docker exec base14 service postgresql restart`
4. Load the frontpage by going to localhost and confirm that it shows the current theme enabled.
5. Go to the appearance page and ensure that the theme is enabled and states the companion module as a dependency (see screenshot)
6. Go to the module page and ensure the companion module is present and enabled (see screenshot)

![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/1566301/a9f41afe-0a36-4620-9a4c-f4803842c9ba)

![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/1566301/88decf13-d4c9-4acb-a7af-5c99b96d03a4)

![image](https://github.com/TripalCultivate/TripalCultivate-Theme/assets/1566301/5dd55175-dd57-42b3-aeff-6f513526654a)
