### PR TITLE
G0.31 Free the docblocks in our coding standards

### DIFF
--- a/.codingstandards.xml
+++ b/.codingstandards.xml
@@ -5,6 +5,8 @@
     <rule ref="Drupal">
         <!-- We want to allow underscores in class property names. -->
         <exclude name="Drupal.NamingConventions.ValidVariableName.LowerCamelName"/>
+        <!-- We want to allow docblocks in more places, namely above "use" -->
+        <exclude name="Drupal.Commenting.InlineComment.DocBlock"/>
     </rule>
 
     <rule ref="DrupalPractice">


### PR DESCRIPTION
**Issue #31**

## Motivation
<!-- This can usually be copied from the issue.
     Please do not just say, go see issue but instead
    copy the relevant details here. -->
We are not happy with the Drupal Coding standards not allowing us to put a docblock above trait use statements within a class. This issue is intended to change the standard so we can keep our double star.

More specifically, we are removing the check that produces the message:

> Inline doc block comments are not allowed; use "/* Comment */" or "// Comment" instead

As shown in the following screenshot.
<img width="1114" alt="Screenshot 2024-11-14 at 4 27 11 PM" src="https://github.com/user-attachments/assets/cd7aa2f6-f51b-439e-b89d-9bb9fa3862bb">

## What does this PR do?
<!-- Please describe each things this PR does.
     For example, a PR may 1) solve a specific bug,
     2) create an automated test to ensure it doesn't return. -->

- [x] This PR alters our coding standards to allow inline docblocks.

## Testing

### Automated Testing
<!-- Please describe each automated test this PR creates
     and provide a list of the assertions it makes using casual language.
     Do not just say things like "asserts the array is not empty"
     but rather say "Ensures that the return value of method X
     with these parameters is not an empty array". -->

No automated testing is needed for coding standard changes.

### Manual Testing
<!-- Describe in detail how someone should manually test this functionality.
     Make sure to include whether they need to build a docker from scratch,
     create any records, configure anything, etc. -->

1. Clone this repo and switch to this branch
2. Open up the repo in VS Code and build a new docker image/container in there.
3. Navigate to `trpcultivate.module` and add an inline docblock.
4. Confirm that you do not see the following error in the "Problems" panel: `Inline doc block comments are not allowed; use "/* Comment */" or "// Comment" instead`
5. Make other mistakes in your inline docblock and confirm that other docblock validation is still in play. (e.g. bad spacing, no empty line after the first description line, too long of text).
6. Make other comment mistakes and confirm they are still picked up (e.g. an \\ comment without any text, lowercase first word in a comment, must end in period).

These were my tests:
<img width="1066" alt="Screenshot 2024-11-14 at 4 41 57 PM" src="https://github.com/user-attachments/assets/82c36ebf-f04a-4ca8-9223-e2c0f00ead9b">
