### PR TITLE
Fix bug in createTestFile method of importer test trait

### DIFF
--- a/tests/src/Traits/TripalCultivateImporterTestTrait.php
+++ b/tests/src/Traits/TripalCultivateImporterTestTrait.php
@@ -25,8 +25,9 @@ trait TripalCultivateImporterTestTrait {
    *     - content[string]: the content to copy into the file as a string
    *     - content[file]: an existing file in the fixtures directory to copy
    *         the contents from.
-   *     - content[fixturepath]: the path to Fixtures relative to the module the
-   *         method was called. Default to Fixtures directory of this module.
+   *     - content[fixturepath]: the absolute path to Fixtures directory
+   *         containing the test file. This should end with a '/'.
+   *         Default to Fixtures directory of this module.
    *     - permissions: permissions to apply to the file using chmod.
    *         Either 'none' for unreadable or the octet (see chmod)
    *         0600: read + write for owner, nothing for everyone else

--- a/tests/src/Traits/TripalCultivateImporterTestTrait.php
+++ b/tests/src/Traits/TripalCultivateImporterTestTrait.php
@@ -24,7 +24,9 @@ trait TripalCultivateImporterTestTrait {
    *         file in the temporary or public files directory.
    *     - content[string]: the content to copy into the file as a string
    *     - content[file]: an existing file in the fixtures directory to copy
-   *         the contents from
+   *         the contents from.
+   *     - content[fixturepath]: the path to Fixtures relative to the module the
+   *         method was called. Default to Fixtures directory of this module.
    *     - permissions: permissions to apply to the file using chmod.
    *         Either 'none' for unreadable or the octet (see chmod)
    *         0600: read + write for owner, nothing for everyone else
@@ -62,7 +64,10 @@ trait TripalCultivateImporterTestTrait {
     // If a test file fixture was provided, create a copy and set this file copy
     // as the file uri value in the file object for this test file.
     if (array_key_exists('file', $details['content']) && !empty($details['content']['file'])) {
-      $path_to_file_fixture = __DIR__ . '/../Fixtures/' . $details['content']['file'];
+      $path_to_fixtures = isset($details['content']['fixturepath']) && $details['content']['fixturepath']
+        ? $details['content']['fixturepath'] : __DIR__ . '/../Fixtures/';
+
+      $path_to_file_fixture = $path_to_fixtures . $details['content']['file'];
 
       $this->assertFileIsReadable(
         $path_to_file_fixture,

--- a/tests/src/Traits/TripalCultivateImporterTestTraitTest.php
+++ b/tests/src/Traits/TripalCultivateImporterTestTraitTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\Tests\tripalcultivate\Traits;
+
+use Drupal\file\Entity\File;
+use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use Drupal\Tests\trpcultivate\Traits\TripalCultivateImporterTestTrait;
+
+/**
+ * Test importer test trait.
+ *
+ * @group trpcultivate_test_trait
+ */
+class TripalCultivateImporterTestTraitTest extends ChadoTestKernelBase {
+
+  use TripalCultivateImporterTestTrait;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'file',
+    'system',
+    'user',
+    'path',
+    'path_alias',
+    'views',
+    'field',
+    'field_ui',
+    'markup',
+    'field_group',
+    'tripal',
+    'tripal_chado',
+    'tripal_layout',
+    'trpcultivate',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() :void {
+    parent::setUp();
+
+    \Drupal::state()->set('is_a_test_environment', TRUE);
+    $this->installEntitySchema('file');
+  }
+
+  /**
+   * Test createTestFile() method in the test trait.
+   */
+  public function testCreateTestFile() {
+    $file_details = [
+      'ext' => 'txt',
+      'mime' => 'text/plain',
+      'content' => [
+        'string' => '',
+        'file' => 'pdf.txt',
+      ],
+    ];
+
+    $file_fixtures = [
+      // Use default module's test Fixtures directory.
+      '',
+      // Use this specific test Fixtures directory.
+      __DIR__ . '/../Fixtures/',
+    ];
+
+    foreach ($file_fixtures as $fixture) {
+      $new_file_details = $file_details;
+      $new_file_details['fixturepath'] = $fixture;
+      $file = $this->createTestFile($new_file_details);
+
+      $this->assertInstanceOf(
+        File::class,
+        $file,
+        'Test trait createTestFile() failed to create expected file object'
+      );
+    }
+  }
+
+}


### PR DESCRIPTION
**Issue #58  Test Trait createTestFiles() could not reference file fixture in Phenotypes**

## Motivation
<!-- This can usually be copied from the issue.
     Please do not just say, go see issue but instead
    copy the relevant details here. -->

Enable test trait createTestFile() method to reference test Fixture files relative to the module it was called.

## What does this PR do?
<!-- Please describe each things this PR does.
     For example, a PR may 1) solve a specific bug,
     2) create an automated test to ensure it doesn't return. -->

- [x] Create a key in details array parameter that allows for specifying path to test Fixtures to reference.
- [x] Setup a test of using file fixture in createTestFile. 

## Testing

### Automated Testing
<!-- Please describe each automated test this PR creates
     and provide a list of the assertions it makes using casual language.
     Do not just say things like "asserts the array is not empty"
     but rather say "Ensures that the return value of method X
     with these parameters is not an empty array". -->

- [x] TripalCultivateImporterTestTraitTest

### Manual Testing
<!-- Describe in detail how someone should manually test this functionality.
     Make sure to include whether they need to build a docker from scratch,
     create any records, configure anything, etc. -->

No manual test.

1. Start a fresh docker image/container on this branch. **You can use the devcontainer approach OR the following commands:**
  ```
  cd ~/Dockers
  git clone https://github.com/TripalCultivate/TripalCultivate trpcultBase-PRNUM
  git checkout BRANCHNAME
  cd trpcultBase-PRNUM
  docker build --tag=trpcultivate-base:reviewPRNUM ./
  docker run --publish=80:80 -tid --name=basePRNUM --volume=`pwd`:/var/www/drupal/web/modules/contrib/TripalCultivate trpcultivate-base:reviewPRNUM
  ```
