### PR TITLE
G4.77 Migrate from Annotations to PHP Attributes in validators

### DIFF
--- a/src/Plugin/Validators/EmptyCell.php
+++ b/src/Plugin/Validators/EmptyCell.php
@@ -5,16 +5,17 @@ namespace Drupal\trpcultivate\Plugin\Validators;
 use Drupal\trpcultivate\Service\ImportValidationHelper;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\ColumnIndices;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Validate empty cells of an importer.
- *
- * @TripalCultivateValidator(
- *   id = "empty_cell",
- *   validator_name = @Translation("Empty Cell Validator"),
- *   input_types = {"header-row", "data-row"},
- * )
  */
+#[TripalCultivateValidator(
+   id: 'empty_cell',
+   validator_name: new TranslatableMarkup('Empty Cell Validator'),
+   input_types: ['header-row', 'data-row'],
+ )]
 class EmptyCell extends TripalCultivateValidatorBase {
 
   /**

--- a/src/Plugin/Validators/GermplasmNameExists.php
+++ b/src/Plugin/Validators/GermplasmNameExists.php
@@ -9,16 +9,17 @@ use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\ColumnIndices;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\Organism;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Validate the existance of a germplasm name in the database.
- *
- * @TripalCultivateValidator(
- *   id = "germplasm_name_exists",
- *   validator_name = @Translation("Germplasm Name Exists Validator"),
- *   input_types = {"data-row"},
- * )
  */
+#[TripalCultivateValidator(
+   id: 'germplasm_name_exists',
+   validator_name: new TranslatableMarkup('Germplasm Name Exists Validator'),
+   input_types: ["data-row"],
+ )]
 class GermplasmNameExists extends TripalCultivateValidatorBase implements ContainerFactoryPluginInterface {
   /**
    * Validator Traits required by this validator.

--- a/src/Plugin/Validators/ProjectExists.php
+++ b/src/Plugin/Validators/ProjectExists.php
@@ -2,18 +2,19 @@
 
 namespace Drupal\trpcultivate\Plugin\Validators;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\Controller\ChadoProjectAutocompleteController;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
 
 /**
  * Validate that project exists.
- *
- * @TripalCultivateValidator(
- *   id = "project_exists",
- *   validator_name = @Translation("Project Exists Validator"),
- *   input_types = {"metadata"}
- * )
  */
+#[TripalCultivateValidator(
+   id: 'project_exists',
+   validator_name: new TranslatableMarkup('Project Exists Validator'),
+   input_types: ['metadata']
+ )]
 class ProjectExists extends TripalCultivateValidatorBase {
 
   /**

--- a/src/Plugin/Validators/ValidDataFile.php
+++ b/src/Plugin/Validators/ValidDataFile.php
@@ -4,20 +4,21 @@ namespace Drupal\trpcultivate\Plugin\Validators;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\trpcultivate\Service\ImportValidationHelper;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\FileTypes;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
 
 /**
  * Validate data file.
- *
- * @TripalCultivateValidator(
- *   id = "valid_data_file",
- *   validator_name = @Translation("Valid Data File Validator"),
- *   input_types = {"file"}
- * )
  */
+#[TripalCultivateValidator(
+   id: 'valid_data_file',
+   validator_name: new TranslatableMarkup('Valid Data File Validator'),
+   input_types: ['file']
+)]
 class ValidDataFile extends TripalCultivateValidatorBase implements ContainerFactoryPluginInterface {
 
   /**

--- a/src/Plugin/Validators/ValidDelimitedFile.php
+++ b/src/Plugin/Validators/ValidDelimitedFile.php
@@ -2,20 +2,21 @@
 
 namespace Drupal\trpcultivate\Plugin\Validators;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\trpcultivate\Service\ImportValidationHelper;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\ColumnCount;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\FileTypes;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
 
 /**
  * Validate that a line in a data file is properly delimited.
- *
- * @TripalCultivateValidator(
- *   id = "valid_delimited_file",
- *   validator_name = @Translation("Valid Delimited File Validator"),
- *   input_types = {"raw-row"}
- * )
  */
+#[TripalCultivateValidator(
+   id: 'valid_delimited_file',
+   validator_name: new TranslatableMarkup('Valid Delimited File Validator'),
+   input_types: ['raw-row']
+ )]
 class ValidDelimitedFile extends TripalCultivateValidatorBase {
 
   /**

--- a/src/Plugin/Validators/ValidHeaders.php
+++ b/src/Plugin/Validators/ValidHeaders.php
@@ -2,20 +2,21 @@
 
 namespace Drupal\trpcultivate\Plugin\Validators;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\trpcultivate\Service\ImportValidationHelper;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\ColumnCount;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\Headers;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
 
 /**
  * Validate that all expected column headers exist.
- *
- * @TripalCultivateValidator(
- *   id = "valid_headers",
- *   validator_name = @Translation("Header Row Validator"),
- *   input_types = {"header-row"}
- * )
  */
+#[TripalCultivateValidator(
+   id: 'valid_headers',
+   validator_name: new TranslatableMarkup('Header Row Validator'),
+   input_types: ['header-row']
+ )]
 class ValidHeaders extends TripalCultivateValidatorBase {
 
   /**

--- a/src/Plugin/Validators/ValueInList.php
+++ b/src/Plugin/Validators/ValueInList.php
@@ -2,20 +2,21 @@
 
 namespace Drupal\trpcultivate\Plugin\Validators;
 
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
 use Drupal\trpcultivate\Service\ImportValidationHelper;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\ColumnIndices;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\ValidValues;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Validate that column only contains a set list of values.
- *
- * @TripalCultivateValidator(
- *   id = "value_in_list",
- *   validator_name = @Translation("Value In List Validator"),
- *   input_types = {"header-row", "data-row"},
- * )
  */
+#[TripalCultivateValidator(
+  id: 'value_in_list',
+  validator_name: new TranslatableMarkup('Value In List Validator'),
+  input_types: ['header-row', 'data-row']
+)]
 class ValueInList extends TripalCultivateValidatorBase {
 
   /**

--- a/src/TripalCultivateValidator/Attribute/TripalCultivateValidator.php
+++ b/src/TripalCultivateValidator/Attribute/TripalCultivateValidator.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\trpcultivate\TripalCultivateValidator\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Defines a data validator attribute object.
+ *
+ * Plugin Namespace: Drupal\trpcultivate\TripalCultivateValidator.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class TripalCultivateValidator extends Plugin {
+
+  /**
+   * Constructs a TripalCultivateValidator attribute.
+   *
+   * @param string $id
+   *   The plugin ID.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup|null $validator_name
+   *   The human-readable name of the validator.
+   * @param array $input_types
+   *   The type of the data this validator supports validating.
+   *   This should be one or more of the following:
+   *   - metadata: for validating the form values of the importer not including
+   *     the file.
+   *   - file: for validating the file object but not its contents.
+   *   - header-row: for validating the first row in the file.
+   *   - data-row: for validating all data rows in the file.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly ?TranslatableMarkup $validator_name = NULL,
+    public readonly ?array $input_types = [],
+  ) {}
+
+}

--- a/src/TripalCultivateValidator/TripalCultivateValidatorManager.php
+++ b/src/TripalCultivateValidator/TripalCultivateValidatorManager.php
@@ -33,6 +33,7 @@ class TripalCultivateValidatorManager extends DefaultPluginManager {
       $namespaces,
       $module_handler,
       'Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorInterface',
+      'Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator',
       'Drupal\trpcultivate\TripalCultivateValidator\Annotation\TripalCultivateValidator'
     );
 

--- a/tests/src/Fixtures/TripalImporter/TestTripalImporter.php
+++ b/tests/src/Fixtures/TripalImporter/TestTripalImporter.php
@@ -6,6 +6,7 @@ use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\tripal_chado\TripalImporter\ChadoImporterBase;
 use Drupal\trpcultivate\Plugin\Validators\ValidDelimitedFile;
@@ -13,6 +14,7 @@ use Drupal\trpcultivate\Service\ImportValidationHelper;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\tripal\TripalImporter\Attribute\TripalImporter;
 
 /**
  * This importer is to help you manually test generic validators.
@@ -40,30 +42,28 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * testing instructions.
  *
  * NOTE: do not edit annotations.
- *
- * @TripalImporter(
- *   id = "trpcultivate-test-importer",
- *   label = @Translation("Tripal Cultivate: Test Importer"),
- *   description = @Translation("A Tripal Importer used to test APIs."),
- *   file_types = {"tsv"},
- *   upload_description = @Translation("Please provide a data file."),
- *   upload_title = @Translation("Import data file*"),
- *   use_analysis = FALSE,
- *   require_analysis = FALSE,
- *   use_button = True,
- *   submit_disabled = FALSE,
- *   button_text = "Import",
- *   file_upload = TRUE,
- *   file_local = FALSE,
- *   file_remote = FALSE,
- *   file_required = TRUE,
- *   cardinality = 1,
- *   menu_path = "",
- *   callback = "",
- *   callback_module = "",
- *   callback_path = "",
- * )
  */
+#[TripalImporter(
+   id: 'trpcultivate-test-importer',
+   label: new TranslatableMarkup('Tripal Cultivate: Test Importer'),
+   description: new TranslatableMarkup('A Tripal Importer used to test APIs.'),
+   file_types: ['tsv'],
+   upload_description: new TranslatableMarkup('Please provide a data file.'),
+   upload_title: new TranslatableMarkup('Import data file*'),
+   use_analysis: FALSE,
+   require_analysis: FALSE,
+   use_button: TRUE,
+   submit_disabled: FALSE,
+   button_text: new TranslatableMarkup('Import'),
+   file_upload: TRUE,
+   file_local: FALSE,
+   file_remote: FALSE,
+   file_required: TRUE,
+   cardinality: 1,
+   menu_path: '',
+   callback: '',
+   callback_path: '',
+  )]
 class TestTripalImporter extends ChadoImporterBase implements ContainerFactoryPluginInterface {
 
   /**

--- a/tests/src/Functional/Display/DisplayValidationResultWindowTest.php
+++ b/tests/src/Functional/Display/DisplayValidationResultWindowTest.php
@@ -6,13 +6,13 @@ use Drupal\Core\Url;
 use Drupal\Component\Utility\Html;
 use Drupal\Tests\tripal_chado\Functional\ChadoTestBrowserBase;
 use Drupal\KernelTests\AssertContentTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Tripal Cultivate Validation Result Window.
- *
- * @group trpcultivate
- * @group displays
  */
+#[Group('trpcultivate')]
+#[Group('displays')]
 class DisplayValidationResultWindowTest extends ChadoTestBrowserBase {
 
   use AssertContentTrait;
@@ -411,9 +411,8 @@ class DisplayValidationResultWindowTest extends ChadoTestBrowserBase {
    * @param array $expected_class
    *   The expected class name an item is tagged with. Each validation item
    *   corresponds to one class name based on the value of the status key.
-   *
-   * @dataProvider provideValidationResultRenderArray
    */
+  #[DataProvider('provideValidationResultRenderArray')]
   public function testResultWindowDisplay(string $scenario, array $validation_result_input, array $expected_class) {
 
     $validation_window = [

--- a/tests/src/Functional/Display/DisplayValidationResultWindowTest.php
+++ b/tests/src/Functional/Display/DisplayValidationResultWindowTest.php
@@ -10,6 +10,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Tripal Cultivate Validation Result Window.
+ *
+ * @group trpcultivate
+ * @group displays
  */
 #[Group('trpcultivate')]
 #[Group('displays')]

--- a/tests/src/Functional/Display/DisplayValidationResultWindowTest.php
+++ b/tests/src/Functional/Display/DisplayValidationResultWindowTest.php
@@ -414,6 +414,8 @@ class DisplayValidationResultWindowTest extends ChadoTestBrowserBase {
    * @param array $expected_class
    *   The expected class name an item is tagged with. Each validation item
    *   corresponds to one class name based on the value of the status key.
+   *
+   * @dataProvider provideValidationResultRenderArray
    */
   #[DataProvider('provideValidationResultRenderArray')]
   public function testResultWindowDisplay(string $scenario, array $validation_result_input, array $expected_class) {

--- a/tests/src/Functional/InstallTest.php
+++ b/tests/src/Functional/InstallTest.php
@@ -9,6 +9,9 @@ use Drupal\tripal_chado\Database\ChadoConnection;
 
 /**
  * Simple test to ensure that main page loads with module enabled.
+ *
+ * @group TrpCultivate
+ * @group Installation
  */
 #[Group('TrpCultivate')]
 #[Group('Installation')]

--- a/tests/src/Functional/InstallTest.php
+++ b/tests/src/Functional/InstallTest.php
@@ -9,10 +9,9 @@ use Drupal\tripal_chado\Database\ChadoConnection;
 
 /**
  * Simple test to ensure that main page loads with module enabled.
- *
- * @group TrpCultivate
- * @group Installation
  */
+#[Group('TrpCultivate')]
+#[Group('Installation')]
 class InstallTest extends ChadoTestBrowserBase {
 
   /**

--- a/tests/src/Kernel/ContentTypes/ContentTypeTest.php
+++ b/tests/src/Kernel/ContentTypes/ContentTypeTest.php
@@ -7,6 +7,9 @@ use Drupal\tripal_chado\Database\ChadoConnection;
 
 /**
  * Tests that the content types and fields associated with them are created.
+ *
+ * @group ContentTypes
+ * @group Fields
  */
 #[Group('ContentTypes')]
 #[Group('Fields')]

--- a/tests/src/Kernel/ContentTypes/ContentTypeTest.php
+++ b/tests/src/Kernel/ContentTypes/ContentTypeTest.php
@@ -7,10 +7,9 @@ use Drupal\tripal_chado\Database\ChadoConnection;
 
 /**
  * Tests that the content types and fields associated with them are created.
- *
- * @group ContentTypes
- * @group Fields
  */
+#[Group('ContentTypes')]
+#[Group('Fields')]
 class ContentTypeTest extends ChadoTestKernelBase {
 
   /**

--- a/tests/src/Kernel/ImplementedHooksTest.php
+++ b/tests/src/Kernel/ImplementedHooksTest.php
@@ -5,12 +5,12 @@ namespace Drupal\Tests\trpcultivate\Kernel;
 use Drupal\Core\Routing\RouteMatch;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\tripal_chado\Database\ChadoConnection;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests our implementation of specific hooks.
- *
- * @group Hooks
  */
+#[Group('Hooks')]
 class ImplementedHooksTest extends ChadoTestKernelBase {
 
   /**
@@ -104,9 +104,8 @@ class ImplementedHooksTest extends ChadoTestKernelBase {
    *   An array describing what we should expect.
    *     - contains_library: TRUE|FALSE indicates whether the
    *       trpcultivate/tripal_entity_type should be attached to the page.
-   *
-   * @dataProvider provideTestRoutes
    */
+  #[DataProvider('provideTestRoutes')]
   public function testPreprocessPage(string $route_name, array $expectations) {
 
     // Firs mock the RouteMatch object. This service is called by our preprocess

--- a/tests/src/Kernel/ImplementedHooksTest.php
+++ b/tests/src/Kernel/ImplementedHooksTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests our implementation of specific hooks.
+ *
+ * @group Hooks
  */
 #[Group('Hooks')]
 class ImplementedHooksTest extends ChadoTestKernelBase {

--- a/tests/src/Kernel/ImplementedHooksTest.php
+++ b/tests/src/Kernel/ImplementedHooksTest.php
@@ -106,6 +106,8 @@ class ImplementedHooksTest extends ChadoTestKernelBase {
    *   An array describing what we should expect.
    *     - contains_library: TRUE|FALSE indicates whether the
    *       trpcultivate/tripal_entity_type should be attached to the page.
+   *
+   * @dataProvider provideTestRoutes
    */
   #[DataProvider('provideTestRoutes')]
   public function testPreprocessPage(string $route_name, array $expectations) {

--- a/tests/src/Kernel/ServiceImportValidationHelperTest.php
+++ b/tests/src/Kernel/ServiceImportValidationHelperTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test import validation helper service.
+ *
+ * @group trpcultivate
+ * @group validation_helper
  */
 #[Group('trpcultivate')]
 #[Group('validation_helper')]

--- a/tests/src/Kernel/ServiceImportValidationHelperTest.php
+++ b/tests/src/Kernel/ServiceImportValidationHelperTest.php
@@ -125,6 +125,8 @@ class ServiceImportValidationHelperTest extends ChadoTestKernelBase {
    *   an exception.
    * @param array|false $expected
    *   The expected returned file delimiter, false if none expected.
+   *
+   * @dataProvider provideMimeTypesForFileDelimiterGetter
    */
   #[DataProvider('provideMimeTypesForFileDelimiterGetter')]
   public function testFileDelimiterGetter(string $scenario, string $mime_type_input, bool $has_exception, string $exception_message, array|false $expected) {
@@ -193,6 +195,8 @@ class ServiceImportValidationHelperTest extends ChadoTestKernelBase {
    * @param string $expected_delimiter
    *   The expected delimiter that is associated to the mime type according to
    *   the mime type - delimiter mapping array.
+   *
+   * @dataProvider provideMimeTypeDelimiters
    */
   #[DataProvider('provideMimeTypeDelimiters')]
   public function testSplitRowIntoColumns(string $expected_mime_type, string $expected_delimiter) {
@@ -427,6 +431,8 @@ class ServiceImportValidationHelperTest extends ChadoTestKernelBase {
    *   - 'expected_errors': The number of expected problems with the array.
    *   - 'expected_details': The details in the message expected to be in the
    *     exception being triggered.
+   *
+   * @dataProvider provideFaultyValidationStatusArray
    */
   #[DataProvider('provideFaultyValidationStatusArray')]
   public function testCheckValidationStatusArray(array $validation_result, array $expectations) {
@@ -696,6 +702,8 @@ class ServiceImportValidationHelperTest extends ChadoTestKernelBase {
    *   It contains the following keys:
    *   - 'header': [COLUMN INDEX][COLUMN VALUE]
    *   - 'rows': [LINE NUMBER][COLUMN INDEX][COLUMN VALUE].
+   *
+   * @dataProvider provideTablesWithGaps
    */
   #[DataProvider('provideTablesWithGaps')]
   public function testFillTableGaps(array $header, array $rows, array $expected_table) {

--- a/tests/src/Kernel/ServiceImportValidationHelperTest.php
+++ b/tests/src/Kernel/ServiceImportValidationHelperTest.php
@@ -4,13 +4,13 @@ namespace Drupal\Tests\tripalcultivate\Kernel;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\trpcultivate\Service\ImportValidationHelper;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test import validation helper service.
- *
- * @group trpcultivate
- * @group validation_helper
  */
+#[Group('trpcultivate')]
+#[Group('validation_helper')]
 class ServiceImportValidationHelperTest extends ChadoTestKernelBase {
 
   /**
@@ -122,9 +122,8 @@ class ServiceImportValidationHelperTest extends ChadoTestKernelBase {
    *   an exception.
    * @param array|false $expected
    *   The expected returned file delimiter, false if none expected.
-   *
-   * @dataProvider provideMimeTypesForFileDelimiterGetter
    */
+  #[DataProvider('provideMimeTypesForFileDelimiterGetter')]
   public function testFileDelimiterGetter(string $scenario, string $mime_type_input, bool $has_exception, string $exception_message, array|false $expected) {
 
     $exception_caught = FALSE;
@@ -191,9 +190,8 @@ class ServiceImportValidationHelperTest extends ChadoTestKernelBase {
    * @param string $expected_delimiter
    *   The expected delimiter that is associated to the mime type according to
    *   the mime type - delimiter mapping array.
-   *
-   * @dataProvider provideMimeTypeDelimiters
    */
+  #[DataProvider('provideMimeTypeDelimiters')]
   public function testSplitRowIntoColumns(string $expected_mime_type, string $expected_delimiter) {
 
     // Create a data row.
@@ -426,9 +424,8 @@ class ServiceImportValidationHelperTest extends ChadoTestKernelBase {
    *   - 'expected_errors': The number of expected problems with the array.
    *   - 'expected_details': The details in the message expected to be in the
    *     exception being triggered.
-   *
-   * @dataProvider provideFaultyValidationStatusArray
    */
+  #[DataProvider('provideFaultyValidationStatusArray')]
   public function testCheckValidationStatusArray(array $validation_result, array $expectations) {
 
     $validator_name = 'My Validator';
@@ -696,9 +693,8 @@ class ServiceImportValidationHelperTest extends ChadoTestKernelBase {
    *   It contains the following keys:
    *   - 'header': [COLUMN INDEX][COLUMN VALUE]
    *   - 'rows': [LINE NUMBER][COLUMN INDEX][COLUMN VALUE].
-   *
-   * @dataProvider provideTablesWithGaps
    */
+  #[DataProvider('provideTablesWithGaps')]
   public function testFillTableGaps(array $header, array $rows, array $expected_table) {
     ImportValidationHelper::fillTableGaps($header, $rows);
 

--- a/tests/src/Kernel/ServiceTemplateGeneratorTest.php
+++ b/tests/src/Kernel/ServiceTemplateGeneratorTest.php
@@ -181,6 +181,8 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
    *     - 'extension': the expected file extension of the template file.
    *     - 'delimiter': the expected delimiter used to encode the header row.
    *     - 'header_row': the expected content (header row) of the file.
+   *
+   * @dataProvider provideParametersForFileTemplateGenerator
    */
   #[DataProvider('provideParametersForFileTemplateGenerator')]
   public function testTemplateGeneratorService($scenario, $importer_id, $column_headers, $file_extensions, $expected) {

--- a/tests/src/Kernel/ServiceTemplateGeneratorTest.php
+++ b/tests/src/Kernel/ServiceTemplateGeneratorTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test file template generator service.
+ *
+ * @group trpcultivate
+ * @group template_generate
  */
 #[Group('trpcultivate')]
 #[Group('template_generate')]

--- a/tests/src/Kernel/ServiceTemplateGeneratorTest.php
+++ b/tests/src/Kernel/ServiceTemplateGeneratorTest.php
@@ -4,13 +4,13 @@ namespace Drupal\Tests\tripalcultivate\Kernel;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test file template generator service.
- *
- * @group trpcultivate
- * @group template_generate
  */
+#[Group('trpcultivate')]
+#[Group('template_generate')]
 class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
 
   /**
@@ -178,9 +178,8 @@ class ServiceTemplateGeneratorTest extends ChadoTestKernelBase {
    *     - 'extension': the expected file extension of the template file.
    *     - 'delimiter': the expected delimiter used to encode the header row.
    *     - 'header_row': the expected content (header row) of the file.
-   *
-   * @dataProvider provideParametersForFileTemplateGenerator
    */
+  #[DataProvider('provideParametersForFileTemplateGenerator')]
   public function testTemplateGeneratorService($scenario, $importer_id, $column_headers, $file_extensions, $expected) {
 
     // Generate the template file.

--- a/tests/src/Kernel/Templates/ImporterWindowTemplatesTest.php
+++ b/tests/src/Kernel/Templates/ImporterWindowTemplatesTest.php
@@ -8,6 +8,9 @@ use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 
 /**
  * Tests window templates used in importer.
+ *
+ * @group trpcultivate
+ * @group templates
  */
 #[Group('trpcultivate')]
 #[Group('templates')]

--- a/tests/src/Kernel/Templates/ImporterWindowTemplatesTest.php
+++ b/tests/src/Kernel/Templates/ImporterWindowTemplatesTest.php
@@ -8,10 +8,9 @@ use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 
 /**
  * Tests window templates used in importer.
- *
- * @group trpcultivate
- * @group templates
  */
+#[Group('trpcultivate')]
+#[Group('templates')]
 class ImporterWindowTemplatesTest extends ChadoTestKernelBase {
 
   /**

--- a/tests/src/Kernel/Validators/FakeValidators/BasicallyBase.php
+++ b/tests/src/Kernel/Validators/FakeValidators/BasicallyBase.php
@@ -3,18 +3,19 @@
 namespace Drupal\Tests\trpcultivate\Kernel\Validators\FakeValidators;
 
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the base class.
- *
- * @TripalCultivateValidator(
- * id = "fake_basically_base",
- * validator_name = @Translation("Basically Base Validator"),
- * input_types = {"header-row", "data-row"}
- * )
  */
+#[TripalCultivateValidator(
+ id: 'fake_basically_base',
+ validator_name: new TranslatableMarkup('Basically Base Validator'),
+ input_types: ['header-row', 'data-row']
+ )]
 class BasicallyBase extends TripalCultivateValidatorBase {
 
 }

--- a/tests/src/Kernel/Validators/FakeValidators/ValidatorColumnCount.php
+++ b/tests/src/Kernel/Validators/FakeValidators/ValidatorColumnCount.php
@@ -4,18 +4,19 @@ namespace Drupal\Tests\trpcultivate\Kernel\Validators\FakeValidators;
 
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\ColumnCount;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the ColumnCount trait.
- *
- * @TripalCultivateValidator(
- *   id = "validator_requiring_column_count",
- *   validator_name = @Translation("Validator Using Column Count Trait"),
- *   input_types = {"header-row"}
- * )
  */
+#[TripalCultivateValidator(
+   id: 'validator_requiring_column_count',
+   validator_name: new TranslatableMarkup('Validator Using Column Count Trait'),
+   input_types: ['header-row']
+ )]
 class ValidatorColumnCount extends TripalCultivateValidatorBase {
 
   use ColumnCount;

--- a/tests/src/Kernel/Validators/FakeValidators/ValidatorColumnIndices.php
+++ b/tests/src/Kernel/Validators/FakeValidators/ValidatorColumnIndices.php
@@ -4,18 +4,19 @@ namespace Drupal\Tests\trpcultivate\Kernel\Validators\FakeValidators;
 
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\ColumnIndices;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the ColumnIndices trait.
- *
- * @TripalCultivateValidator(
- * id = "validator_requiring_column_indices",
- * validator_name = @Translation("Validator Using ColumnIndices Trait"),
- * input_types = {"header-row", "data-row"}
- * )
  */
+#[TripalCultivateValidator(
+ id: 'validator_requiring_column_indices',
+ validator_name: new TranslatableMarkup('Validator Using ColumnIndices Trait'),
+ input_types: ['header-row', 'data-row']
+)]
 class ValidatorColumnIndices extends TripalCultivateValidatorBase {
 
   use ColumnIndices;

--- a/tests/src/Kernel/Validators/FakeValidators/ValidatorFileTypes.php
+++ b/tests/src/Kernel/Validators/FakeValidators/ValidatorFileTypes.php
@@ -2,20 +2,21 @@
 
 namespace Drupal\Tests\trpcultivate\Kernel\Validators\FakeValidators;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\FileTypes;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
 
 /**
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the FileTypes trait.
- *
- * @TripalCultivateValidator(
- *   id = "validator_requiring_filetypes",
- *   validator_name = @Translation("Validator Using File Types Trait"),
- *   input_types = {"file"}
- * )
  */
+#[TripalCultivateValidator(
+   id: 'validator_requiring_filetypes',
+   validator_name: new TranslatableMarkup('Validator Using File Types Trait'),
+   input_types: ['file']
+ )]
 class ValidatorFileTypes extends TripalCultivateValidatorBase {
 
   use FileTypes;

--- a/tests/src/Kernel/Validators/FakeValidators/ValidatorHeaders.php
+++ b/tests/src/Kernel/Validators/FakeValidators/ValidatorHeaders.php
@@ -2,20 +2,21 @@
 
 namespace Drupal\Tests\trpcultivate\Kernel\Validators\FakeValidators;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\Headers;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
 
 /**
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the Headers trait.
- *
- * @TripalCultivateValidator(
- *   id = "validator_requiring_headers",
- *   validator_name = @Translation("Validator Using Headers Trait"),
- *   input_types = {"header-row", "data-row"}
- * )
  */
+#[TripalCultivateValidator(
+   id: 'validator_requiring_headers',
+   validator_name: new TranslatableMarkup('Validator Using Headers Trait'),
+   input_types: ['header-row', 'data-row']
+ )]
 class ValidatorHeaders extends TripalCultivateValidatorBase {
 
   use Headers;

--- a/tests/src/Kernel/Validators/FakeValidators/ValidatorOrganism.php
+++ b/tests/src/Kernel/Validators/FakeValidators/ValidatorOrganism.php
@@ -5,18 +5,19 @@ namespace Drupal\Tests\trpcultivate\Kernel\Validators\FakeValidators;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\Organism;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the Organism trait.
- *
- * @TripalCultivateValidator(
- *   id = "validator_requiring_organism",
- *   validator_name = @Translation("Validator Using Organism Trait"),
- *   input_types = {"header-row", "data-row"}
- * )
  */
+#[TripalCultivateValidator(
+   id: 'validator_requiring_organism',
+   validator_name: new TranslatableMarkup('Validator Using Organism Trait'),
+   input_types: ['header-row', 'data-row']
+ )]
 class ValidatorOrganism extends TripalCultivateValidatorBase {
 
   use Organism;

--- a/tests/src/Kernel/Validators/FakeValidators/ValidatorOrganismNOConnection.php
+++ b/tests/src/Kernel/Validators/FakeValidators/ValidatorOrganismNOConnection.php
@@ -5,18 +5,19 @@ namespace Drupal\Tests\trpcultivate\Kernel\Validators\FakeValidators;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\Organism;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the Organism trait with NO ChadoConnection.
- *
- * @TripalCultivateValidator(
- *   id = "validator_requiring_organism_no_connection",
- *   validator_name = @Translation("Validator Using Organism Trait NO Connection"),
- *   input_types = {"header-row", "data-row"}
- * )
  */
+#[TripalCultivateValidator(
+   id: 'validator_requiring_organism_no_connection',
+   validator_name: new TranslatableMarkup('Validator Using Organism Trait NO Connection'),
+   input_types: ['header-row', 'data-row']
+ )]
 class ValidatorOrganismNOConnection extends TripalCultivateValidatorBase {
 
   use Organism;

--- a/tests/src/Kernel/Validators/FakeValidators/ValidatorValidValues.php
+++ b/tests/src/Kernel/Validators/FakeValidators/ValidatorValidValues.php
@@ -4,18 +4,19 @@ namespace Drupal\Tests\trpcultivate\Kernel\Validators\FakeValidators;
 
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorBase;
 use Drupal\trpcultivate\TripalCultivateValidator\ValidatorTraits\ValidValues;
+use Drupal\trpcultivate\TripalCultivateValidator\Attribute\TripalCultivateValidator;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Fake Validator that does not implement any of its own methods.
  *
  * Used to test the ValidValues trait.
- *
- * @TripalCultivateValidator(
- * id = "validator_requiring_valid_values",
- * validator_name = @Translation("Validator Using ValidValues Trait"),
- * input_types = {"header-row", "data-row"}
- * )
  */
+#[TripalCultivateValidator(
+ id: 'validator_requiring_valid_values',
+ validator_name: new TranslatableMarkup('Validator Using ValidValues Trait'),
+ input_types: ['header-row', 'data-row']
+ )]
 class ValidatorValidValues extends TripalCultivateValidatorBase {
 
   use ValidValues;

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitColumnCountTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitColumnCountTest.php
@@ -4,13 +4,13 @@ namespace Drupal\Tests\trpcultivate\Kernel\Validators;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate\Kernel\Validators\FakeValidators\ValidatorColumnCount;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests the ColumnCount validator trait.
- *
- * @group trpcultivate
- * @group validator_traits
  */
+#[Group('trpcultivate')]
+#[Group('validator_traits')]
 class ValidatorTraitColumnCountTest extends ChadoTestKernelBase {
 
   /**
@@ -165,9 +165,8 @@ class ValidatorTraitColumnCountTest extends ChadoTestKernelBase {
 
   /**
    * Test getter method to get expected columns.
-   *
-   * @dataProvider provideExpectedColumnsForSetter
    */
+  #[DataProvider('provideExpectedColumnsForSetter')]
   public function testValidatorSetterAndGetter($scenario, $column_numbers_input, $strict_input, $expected, $exception) {
 
     // Test the setter method.

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitColumnCountTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitColumnCountTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests the ColumnCount validator trait.
+ *
+ * @group trpcultivate
+ * @group validator_traits
  */
 #[Group('trpcultivate')]
 #[Group('validator_traits')]

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitColumnCountTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitColumnCountTest.php
@@ -168,6 +168,8 @@ class ValidatorTraitColumnCountTest extends ChadoTestKernelBase {
 
   /**
    * Test getter method to get expected columns.
+   *
+   * @dataProvider provideExpectedColumnsForSetter
    */
   #[DataProvider('provideExpectedColumnsForSetter')]
   public function testValidatorSetterAndGetter($scenario, $column_numbers_input, $strict_input, $expected, $exception) {

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitColumnIndicesTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitColumnIndicesTest.php
@@ -7,10 +7,9 @@ use Drupal\Tests\trpcultivate\Kernel\Validators\FakeValidators\ValidatorColumnIn
 
 /**
  * Tests the ColumnIndices validator trait.
- *
- * @group trpcultivate
- * @group validator_traits
  */
+#[Group('trpcultivate')]
+#[Group('validator_traits')]
 class ValidatorTraitColumnIndicesTest extends ChadoTestKernelBase {
 
   /**

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitColumnIndicesTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitColumnIndicesTest.php
@@ -7,6 +7,9 @@ use Drupal\Tests\trpcultivate\Kernel\Validators\FakeValidators\ValidatorColumnIn
 
 /**
  * Tests the ColumnIndices validator trait.
+ *
+ * @group trpcultivate
+ * @group validator_traits
  */
 #[Group('trpcultivate')]
 #[Group('validator_traits')]

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitFileTypesTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitFileTypesTest.php
@@ -10,6 +10,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests the FileTypes validator trait.
+ *
+ * @group trpcultivate
+ * @group validator_traits
  */
 #[Group('trpcultivate')]
 #[Group('validator_traits')]

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitFileTypesTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitFileTypesTest.php
@@ -525,6 +525,8 @@ class ValidatorTraitFileTypesTest extends ChadoTestKernelBase {
    * @param array $expected_exception_message
    *   An array of expected exception messages with the key being the method
    *   name and value being the expected message (empty string if not expected).
+   *
+   * @dataProvider provideExtensionsForSetter
    */
   #[DataProvider('provideExtensionsForSetter')]
   public function testSupportedMimeTypes($scenario, $file_extensions, $expected_mime_types, $expected_exception_thrown, $expected_exception_message) {
@@ -682,6 +684,8 @@ class ValidatorTraitFileTypesTest extends ChadoTestKernelBase {
    *   - 'logged_message': an array of expected logged messages with
    *      the keys being the method and the value being the message we expect
    *      (empty string if no logged message expected)
+   *
+   * @dataProvider provideMimeTypeForSetter
    */
   #[DataProvider('provideMimeTypeForSetter')]
   public function testFileMimeType($scenario, $mime_type, $expectations) {

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitFileTypesTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitFileTypesTest.php
@@ -6,13 +6,13 @@ use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate\Kernel\Validators\FakeValidators\ValidatorFileTypes;
 use Drupal\Tests\trpcultivate\Traits\TripalCultivateImporterTestTrait;
 use Drupal\tripal\Services\TripalLogger;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests the FileTypes validator trait.
- *
- * @group trpcultivate
- * @group validator_traits
  */
+#[Group('trpcultivate')]
+#[Group('validator_traits')]
 class ValidatorTraitFileTypesTest extends ChadoTestKernelBase {
 
   use TripalCultivateImporterTestTrait;
@@ -522,9 +522,8 @@ class ValidatorTraitFileTypesTest extends ChadoTestKernelBase {
    * @param array $expected_exception_message
    *   An array of expected exception messages with the key being the method
    *   name and value being the expected message (empty string if not expected).
-   *
-   * @dataProvider provideExtensionsForSetter
    */
+  #[DataProvider('provideExtensionsForSetter')]
   public function testSupportedMimeTypes($scenario, $file_extensions, $expected_mime_types, $expected_exception_thrown, $expected_exception_message) {
 
     // These exception messages are expected when we intially call the getter
@@ -680,9 +679,8 @@ class ValidatorTraitFileTypesTest extends ChadoTestKernelBase {
    *   - 'logged_message': an array of expected logged messages with
    *      the keys being the method and the value being the message we expect
    *      (empty string if no logged message expected)
-   *
-   * @dataProvider provideMimeTypeForSetter
    */
+  #[DataProvider('provideMimeTypeForSetter')]
   public function testFileMimeType($scenario, $mime_type, $expectations) {
 
     // This exception message is expected when we intially call the getter

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitHeadersTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitHeadersTest.php
@@ -454,6 +454,8 @@ class ValidatorTraitHeadersTest extends ChadoTestKernelBase {
    *   An array of exception messages that setter and getters will throw.
    * @param array $expected
    *   An array of headers array each getter will produce.
+   *
+   * @dataProvider provideHeadersForHeadersSetter
    */
   #[DataProvider('provideHeadersForHeadersSetter')]
   public function testHeaderSetterAndGetters($scenario, $headers_input, $types_input, $has_exception, $exception_message, $expected) {

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitHeadersTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitHeadersTest.php
@@ -4,13 +4,13 @@ namespace Drupal\Tests\trpcultivate\Kernel\Validators;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate\Kernel\Validators\FakeValidators\ValidatorHeaders;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests the Headers validator trait.
- *
- * @group trpcultivate
- * @group validator_traits
  */
+#[Group('trpcultivate')]
+#[Group('validator_traits')]
 class ValidatorTraitHeadersTest extends ChadoTestKernelBase {
 
   /**
@@ -451,9 +451,8 @@ class ValidatorTraitHeadersTest extends ChadoTestKernelBase {
    *   An array of exception messages that setter and getters will throw.
    * @param array $expected
    *   An array of headers array each getter will produce.
-   *
-   * @dataProvider provideHeadersForHeadersSetter
    */
+  #[DataProvider('provideHeadersForHeadersSetter')]
   public function testHeaderSetterAndGetters($scenario, $headers_input, $types_input, $has_exception, $exception_message, $expected) {
 
     // Test setter method.

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitHeadersTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitHeadersTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests the Headers validator trait.
+ *
+ * @group trpcultivate
+ * @group validator_traits
  */
 #[Group('trpcultivate')]
 #[Group('validator_traits')]

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitOrganismMissingConnectionTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitOrganismMissingConnectionTest.php
@@ -8,10 +8,9 @@ use Drupal\tripal_chado\Database\ChadoConnection;
 
 /**
  * Tests the Organism validator trait.
- *
- * @group trpcultivate
- * @group validator_traits
  */
+#[Group('trpcultivate')]
+#[Group('validator_traits')]
 class ValidatorTraitOrganismMissingConnectionTest extends ChadoTestKernelBase {
 
   /**

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitOrganismMissingConnectionTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitOrganismMissingConnectionTest.php
@@ -8,6 +8,9 @@ use Drupal\tripal_chado\Database\ChadoConnection;
 
 /**
  * Tests the Organism validator trait.
+ *
+ * @group trpcultivate
+ * @group validator_traits
  */
 #[Group('trpcultivate')]
 #[Group('validator_traits')]

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitOrganismTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitOrganismTest.php
@@ -9,6 +9,9 @@ use Drupal\tripal_chado\Database\ChadoConnection;
 
 /**
  * Tests the Organism validator trait.
+ *
+ * @group trpcultivate
+ * @group validator_traits
  */
 #[Group('trpcultivate')]
 #[Group('validator_traits')]

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitOrganismTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitOrganismTest.php
@@ -9,10 +9,9 @@ use Drupal\tripal_chado\Database\ChadoConnection;
 
 /**
  * Tests the Organism validator trait.
- *
- * @group trpcultivate
- * @group validator_traits
  */
+#[Group('trpcultivate')]
+#[Group('validator_traits')]
 class ValidatorTraitOrganismTest extends ChadoTestKernelBase {
 
   /**

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitValidValuesTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitValidValuesTest.php
@@ -7,10 +7,9 @@ use Drupal\Tests\trpcultivate\Kernel\Validators\FakeValidators\ValidatorValidVal
 
 /**
  * Tests the ValidValues validator trait.
- *
- * @group trpcultivate
- * @group validator_traits
  */
+#[Group('trpcultivate')]
+#[Group('validator_traits')]
 class ValidatorTraitValidValuesTest extends ChadoTestKernelBase {
 
   /**

--- a/tests/src/Kernel/Validators/Traits/ValidatorTraitValidValuesTest.php
+++ b/tests/src/Kernel/Validators/Traits/ValidatorTraitValidValuesTest.php
@@ -7,6 +7,9 @@ use Drupal\Tests\trpcultivate\Kernel\Validators\FakeValidators\ValidatorValidVal
 
 /**
  * Tests the ValidValues validator trait.
+ *
+ * @group trpcultivate
+ * @group validator_traits
  */
 #[Group('trpcultivate')]
 #[Group('validator_traits')]

--- a/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -10,6 +10,9 @@ use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
 
 /**
  * Tests Tripal Cultivate Validator Base functions.
+ *
+ * @group trpcultivate
+ * @group validators
  */
 #[Group('trpcultivate')]
 #[Group('validators')]

--- a/tests/src/Kernel/Validators/ValidatorBaseTest.php
+++ b/tests/src/Kernel/Validators/ValidatorBaseTest.php
@@ -10,10 +10,9 @@ use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
 
 /**
  * Tests Tripal Cultivate Validator Base functions.
- *
- * @group trpcultivate
- * @group validators
  */
+#[Group('trpcultivate')]
+#[Group('validators')]
 class ValidatorBaseTest extends ChadoTestKernelBase {
 
   /**

--- a/tests/src/Kernel/Validators/ValidatorEmptyCellProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorEmptyCellProcessTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test any message process methods for the EmptyCell validator.
+ *
+ * @group trpcultivate
+ * @group validators
  */
 #[Group('trpcultivate')]
 #[Group('validators')]

--- a/tests/src/Kernel/Validators/ValidatorEmptyCellProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorEmptyCellProcessTest.php
@@ -3,13 +3,13 @@
 namespace Drupal\Tests\trpcultivate\Kernel\Validators;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test any message process methods for the EmptyCell validator.
- *
- * @group trpcultivate
- * @group validators
  */
+#[Group('trpcultivate')]
+#[Group('validators')]
 class ValidatorEmptyCellProcessTest extends ChadoTestKernelBase {
 
   /**
@@ -264,9 +264,8 @@ class ValidatorEmptyCellProcessTest extends ChadoTestKernelBase {
    *     the failed validation status, further keyed by:
    *     - 'expected_columns': A comma-separated list of column headers that
    *       map to the expected columns with empty values.
-   *
-   * @dataProvider provideEmptyCellFailedCases
    */
+  #[DataProvider('provideEmptyCellFailedCases')]
   public function testProcessListWithDescribedTable(array $validation_results, array $metadata, array $tokens, array $expectations) {
 
     $render_array = $this->validator_instance::processListWithDescribedTable($validation_results, $metadata, $tokens);
@@ -423,9 +422,8 @@ class ValidatorEmptyCellProcessTest extends ChadoTestKernelBase {
    *   keys:
    *   - 'expected_message': The exception message that is expected to be
    *     triggered.
-   *
-   * @dataProvider providePassedAndUnrecognizableCases
    */
+  #[DataProvider('providePassedAndUnrecognizableCases')]
   public function testProcessListWithDescribedTableExceptions(array $validation_results, array $metadata, array $tokens, array $expectations) {
 
     // Test with a passed validation case string.

--- a/tests/src/Kernel/Validators/ValidatorEmptyCellProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorEmptyCellProcessTest.php
@@ -267,6 +267,8 @@ class ValidatorEmptyCellProcessTest extends ChadoTestKernelBase {
    *     the failed validation status, further keyed by:
    *     - 'expected_columns': A comma-separated list of column headers that
    *       map to the expected columns with empty values.
+   *
+   * @dataProvider provideEmptyCellFailedCases
    */
   #[DataProvider('provideEmptyCellFailedCases')]
   public function testProcessListWithDescribedTable(array $validation_results, array $metadata, array $tokens, array $expectations) {
@@ -425,6 +427,8 @@ class ValidatorEmptyCellProcessTest extends ChadoTestKernelBase {
    *   keys:
    *   - 'expected_message': The exception message that is expected to be
    *     triggered.
+   *
+   * @dataProvider providePassedAndUnrecognizableCases
    */
   #[DataProvider('providePassedAndUnrecognizableCases')]
   public function testProcessListWithDescribedTableExceptions(array $validation_results, array $metadata, array $tokens, array $expectations) {

--- a/tests/src/Kernel/Validators/ValidatorEmptyCellTest.php
+++ b/tests/src/Kernel/Validators/ValidatorEmptyCellTest.php
@@ -8,6 +8,10 @@ use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
 
 /**
  * Tests the Empty Cell validator.
+ *
+ * @group trpcultivate
+ * @group validators
+ * @group row_validators
  */
 #[Group('trpcultivate')]
 #[Group('validators')]

--- a/tests/src/Kernel/Validators/ValidatorEmptyCellTest.php
+++ b/tests/src/Kernel/Validators/ValidatorEmptyCellTest.php
@@ -8,11 +8,10 @@ use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
 
 /**
  * Tests the Empty Cell validator.
- *
- * @group trpcultivate
- * @group validators
- * @group row_validators
  */
+#[Group('trpcultivate')]
+#[Group('validators')]
+#[Group('row_validators')]
 class ValidatorEmptyCellTest extends ChadoTestKernelBase {
 
   /**

--- a/tests/src/Kernel/Validators/ValidatorGermplasmNameExistsProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorGermplasmNameExistsProcessTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests any message processing methods for the GermplasmNameExists validator.
+ *
+ * @group trpcultivate
+ * @group validators
  */
 #[Group('trpcultivate')]
 #[Group('validators')]

--- a/tests/src/Kernel/Validators/ValidatorGermplasmNameExistsProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorGermplasmNameExistsProcessTest.php
@@ -451,6 +451,8 @@ class ValidatorGermplasmNameExistsProcessTest extends ChadoTestKernelBase {
    *       column header name of a cell in this row and its value is the
    *       problematic germplasm name. For example:
    *        '2' => [ 'Germplasm Name' => 'Invalid Value' ].
+   *
+   * @dataProvider provideGermplasmNameExistsFailedCases
    */
   #[DataProvider('provideGermplasmNameExistsFailedCases')]
   public function testProcessListWithDescribedTable(array $validation_results, array $tokens, array $metadata, array $expectations) {
@@ -695,6 +697,8 @@ class ValidatorGermplasmNameExistsProcessTest extends ChadoTestKernelBase {
    * @param string $message
    *   - The expected message to be displayed in the returned render array for
    *     this scenario.
+   *
+   * @dataProvider provideGermplasmNameExistsEmptyCellCase
    */
   #[DataProvider('provideGermplasmNameExistsEmptyCellCase')]
   public function testProcessListWithDescribedTableEmptyCell(array $validation_results, array $tokens, array $metadata, string $message) {
@@ -865,6 +869,8 @@ class ValidatorGermplasmNameExistsProcessTest extends ChadoTestKernelBase {
    *   keys:
    *   - 'expected_message': The exception message that is expected to be
    *     triggered.
+   *
+   * @dataProvider providePassedAndUnrecognizableCases
    */
   #[DataProvider('providePassedAndUnrecognizableCases')]
   public function testProcessListWithDescribedTableExceptions(array $validation_results, array $metadata, array $tokens, array $expectations) {

--- a/tests/src/Kernel/Validators/ValidatorGermplasmNameExistsProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorGermplasmNameExistsProcessTest.php
@@ -4,13 +4,13 @@ namespace Drupal\Tests\trpcultivate\Kernel\Validators;
 
 use Drupal\Core\Render\Renderer;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests any message processing methods for the GermplasmNameExists validator.
- *
- * @group trpcultivate
- * @group validators
  */
+#[Group('trpcultivate')]
+#[Group('validators')]
 class ValidatorGermplasmNameExistsProcessTest extends ChadoTestKernelBase {
 
   /**
@@ -448,9 +448,8 @@ class ValidatorGermplasmNameExistsProcessTest extends ChadoTestKernelBase {
    *       column header name of a cell in this row and its value is the
    *       problematic germplasm name. For example:
    *        '2' => [ 'Germplasm Name' => 'Invalid Value' ].
-   *
-   * @dataProvider provideGermplasmNameExistsFailedCases
    */
+  #[DataProvider('provideGermplasmNameExistsFailedCases')]
   public function testProcessListWithDescribedTable(array $validation_results, array $tokens, array $metadata, array $expectations) {
 
     // Call the process method on our validation result.
@@ -693,9 +692,8 @@ class ValidatorGermplasmNameExistsProcessTest extends ChadoTestKernelBase {
    * @param string $message
    *   - The expected message to be displayed in the returned render array for
    *     this scenario.
-   *
-   * @dataProvider provideGermplasmNameExistsEmptyCellCase
    */
+  #[DataProvider('provideGermplasmNameExistsEmptyCellCase')]
   public function testProcessListWithDescribedTableEmptyCell(array $validation_results, array $tokens, array $metadata, string $message) {
 
     // Call the process method on our validation result.
@@ -864,9 +862,8 @@ class ValidatorGermplasmNameExistsProcessTest extends ChadoTestKernelBase {
    *   keys:
    *   - 'expected_message': The exception message that is expected to be
    *     triggered.
-   *
-   * @dataProvider providePassedAndUnrecognizableCases
    */
+  #[DataProvider('providePassedAndUnrecognizableCases')]
   public function testProcessListWithDescribedTableExceptions(array $validation_results, array $metadata, array $tokens, array $expectations) {
 
     $exception_caught = FALSE;

--- a/tests/src/Kernel/Validators/ValidatorGermplasmNameExistsTest.php
+++ b/tests/src/Kernel/Validators/ValidatorGermplasmNameExistsTest.php
@@ -9,6 +9,10 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Tripal Cultivate Germplasm Name Exists Validator Plugin.
+ *
+ * @group trpcultivate
+ * @group validators
+ * @group row_validators
  */
 #[Group('trpcultivate')]
 #[Group('validators')]

--- a/tests/src/Kernel/Validators/ValidatorGermplasmNameExistsTest.php
+++ b/tests/src/Kernel/Validators/ValidatorGermplasmNameExistsTest.php
@@ -398,6 +398,8 @@ class ValidatorGermplasmNameExistsTest extends ChadoTestKernelBase {
    *       cannot be looked up in the database.
    *        - A list containing the indices of the empty cells (This can only
    *          be a subset of $indices).
+   *
+   * @dataProvider provideRowToGermplasmNameExists
    */
   #[DataProvider('provideRowToGermplasmNameExists')]
   public function testValidatorGermplasmNameExists(array $indices, array $row_values, array $expectations) {

--- a/tests/src/Kernel/Validators/ValidatorGermplasmNameExistsTest.php
+++ b/tests/src/Kernel/Validators/ValidatorGermplasmNameExistsTest.php
@@ -5,14 +5,14 @@ namespace Drupal\Tests\trpcultivate\Kernel\Validators;
 use Drupal\tripal_chado\Database\ChadoConnection;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Tripal Cultivate Germplasm Name Exists Validator Plugin.
- *
- * @group trpcultivate
- * @group validators
- * @group row_validators
  */
+#[Group('trpcultivate')]
+#[Group('validators')]
+#[Group('row_validators')]
 class ValidatorGermplasmNameExistsTest extends ChadoTestKernelBase {
 
   /**
@@ -394,9 +394,8 @@ class ValidatorGermplasmNameExistsTest extends ChadoTestKernelBase {
    *       cannot be looked up in the database.
    *        - A list containing the indices of the empty cells (This can only
    *          be a subset of $indices).
-   *
-   * @dataProvider provideRowToGermplasmNameExists
    */
+  #[DataProvider('provideRowToGermplasmNameExists')]
   public function testValidatorGermplasmNameExists(array $indices, array $row_values, array $expectations) {
 
     // Create a plugin instance for this validator.

--- a/tests/src/Kernel/Validators/ValidatorProjectExistsTest.php
+++ b/tests/src/Kernel/Validators/ValidatorProjectExistsTest.php
@@ -10,6 +10,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Tripal Cultivate Project Exists Validator Plugins.
+ *
+ * @group trpcultivate
+ * @group validators
  */
 #[Group('trpcultivate')]
 #[Group('validators')]

--- a/tests/src/Kernel/Validators/ValidatorProjectExistsTest.php
+++ b/tests/src/Kernel/Validators/ValidatorProjectExistsTest.php
@@ -228,6 +228,8 @@ class ValidatorProjectExistsTest extends ChadoTestKernelBase {
    *     - 'id': the failed item if the input was the project id.
    *     Both name and id key corresponds to project name and project id value
    *     in the $test_project property, respectively.
+   *
+   * @dataProvider provideProjectToProjectExistsValidator
    */
   #[DataProvider('provideProjectToProjectExistsValidator')]
   public function testProjectExists($scenario, $test_key, $expected) {

--- a/tests/src/Kernel/Validators/ValidatorProjectExistsTest.php
+++ b/tests/src/Kernel/Validators/ValidatorProjectExistsTest.php
@@ -6,13 +6,13 @@ use Drupal\Core\Form\FormState;
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager;
 use Drupal\tripal_chado\Database\ChadoConnection;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Tripal Cultivate Project Exists Validator Plugins.
- *
- * @group trpcultivate
- * @group validators
  */
+#[Group('trpcultivate')]
+#[Group('validators')]
 class ValidatorProjectExistsTest extends ChadoTestKernelBase {
 
   /**
@@ -225,9 +225,8 @@ class ValidatorProjectExistsTest extends ChadoTestKernelBase {
    *     - 'id': the failed item if the input was the project id.
    *     Both name and id key corresponds to project name and project id value
    *     in the $test_project property, respectively.
-   *
-   * @dataProvider provideProjectToProjectExistsValidator
    */
+  #[DataProvider('provideProjectToProjectExistsValidator')]
   public function testProjectExists($scenario, $test_key, $expected) {
     // Create a plugin instance for this validator.
     $validator_id = 'project_exists';

--- a/tests/src/Kernel/Validators/ValidatorValidDataFileProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidDataFileProcessTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test any message process methods for the ValidDataFile validator.
+ *
+ * @group trpcultivate
+ * @group validators
  */
 #[Group('trpcultivate')]
 #[Group('validators')]

--- a/tests/src/Kernel/Validators/ValidatorValidDataFileProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidDataFileProcessTest.php
@@ -3,13 +3,13 @@
 namespace Drupal\Tests\trpcultivate\Kernel\Validators;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test any message process methods for the ValidDataFile validator.
- *
- * @group trpcultivate
- * @group validators
  */
+#[Group('trpcultivate')]
+#[Group('validators')]
 class ValidatorValidDataFileProcessTest extends ChadoTestKernelBase {
 
   /**
@@ -339,9 +339,8 @@ class ValidatorValidDataFileProcessTest extends ChadoTestKernelBase {
    *       process method for this scenario.
    *     - 'expected_item_count': The number of failed items expected.
    *     - 'expected_item': The expected failed item.
-   *
-   * @dataProvider provideValidDataFileFailedCases
    */
+  #[DataProvider('provideValidDataFileFailedCases')]
   public function testProcessItemWithSimpleList(array $validation_status, array $tokens, array $expectations) {
 
     // Call the process method on our validation result.
@@ -451,9 +450,8 @@ class ValidatorValidDataFileProcessTest extends ChadoTestKernelBase {
    *   following keys:
    *     - 'expected_message': The exception message that is expected to be
    *       triggered.
-   *
-   * @dataProvider providePassedAndUnrecognizableCases
    */
+  #[DataProvider('providePassedAndUnrecognizableCases')]
   public function testProcessItemWithSimpleListExceptions(array $validation_status, array $tokens, array $expectations) {
 
     // Test with a passed validation case string.

--- a/tests/src/Kernel/Validators/ValidatorValidDataFileProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidDataFileProcessTest.php
@@ -342,6 +342,8 @@ class ValidatorValidDataFileProcessTest extends ChadoTestKernelBase {
    *       process method for this scenario.
    *     - 'expected_item_count': The number of failed items expected.
    *     - 'expected_item': The expected failed item.
+   *
+   * @dataProvider provideValidDataFileFailedCases
    */
   #[DataProvider('provideValidDataFileFailedCases')]
   public function testProcessItemWithSimpleList(array $validation_status, array $tokens, array $expectations) {
@@ -453,6 +455,8 @@ class ValidatorValidDataFileProcessTest extends ChadoTestKernelBase {
    *   following keys:
    *     - 'expected_message': The exception message that is expected to be
    *       triggered.
+   *
+   * @dataProvider providePassedAndUnrecognizableCases
    */
   #[DataProvider('providePassedAndUnrecognizableCases')]
   public function testProcessItemWithSimpleListExceptions(array $validation_status, array $tokens, array $expectations) {

--- a/tests/src/Kernel/Validators/ValidatorValidDataFileTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidDataFileTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Tripal Cultivate Data File Validator Plugins.
+ *
+ * @group trpcultivate
+ * @group validators
  */
 #[Group('trpcultivate')]
 #[Group('validators')]

--- a/tests/src/Kernel/Validators/ValidatorValidDataFileTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidDataFileTest.php
@@ -410,6 +410,8 @@ class ValidatorValidDataFileTest extends ChadoTestKernelBase {
    *     - 'fid': the file id number.
    *     - 'mime': the file MIME type.
    *     - 'extension': the file extension.
+   *
+   * @dataProvider provideFileForDataFileValidator
    */
   #[DataProvider('provideFileForDataFileValidator')]
   public function testDataFileInput(string $scenario, string $test_file_key, array $expected) {

--- a/tests/src/Kernel/Validators/ValidatorValidDataFileTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidDataFileTest.php
@@ -4,13 +4,13 @@ namespace Drupal\Tests\trpcultivate\Kernel\Validators;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate\Traits\TripalCultivateImporterTestTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Tripal Cultivate Data File Validator Plugins.
- *
- * @group trpcultivate
- * @group validators
  */
+#[Group('trpcultivate')]
+#[Group('validators')]
 class ValidatorValidDataFileTest extends ChadoTestKernelBase {
 
   use TripalCultivateImporterTestTrait;
@@ -407,9 +407,8 @@ class ValidatorValidDataFileTest extends ChadoTestKernelBase {
    *     - 'fid': the file id number.
    *     - 'mime': the file MIME type.
    *     - 'extension': the file extension.
-   *
-   * @dataProvider provideFileForDataFileValidator
    */
+  #[DataProvider('provideFileForDataFileValidator')]
   public function testDataFileInput(string $scenario, string $test_file_key, array $expected) {
     $file_input = $this->test_files[$test_file_key];
     $fid = $file_input['fid'];

--- a/tests/src/Kernel/Validators/ValidatorValidDelimitedFileProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidDelimitedFileProcessTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test any message process methods for the ValidDelimitedFile validator.
+ *
+ * @group trpcultivate
+ * @group validators
  */
 #[Group('trpcultivate')]
 #[Group('validators')]

--- a/tests/src/Kernel/Validators/ValidatorValidDelimitedFileProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidDelimitedFileProcessTest.php
@@ -3,13 +3,13 @@
 namespace Drupal\Tests\trpcultivate\Kernel\Validators;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test any message process methods for the ValidDelimitedFile validator.
- *
- * @group trpcultivate
- * @group validators
  */
+#[Group('trpcultivate')]
+#[Group('validators')]
 class ValidatorValidDelimitedFileProcessTest extends ChadoTestKernelBase {
 
   /**
@@ -407,9 +407,8 @@ class ValidatorValidDelimitedFileProcessTest extends ChadoTestKernelBase {
    *   - 1+ arrays keyed by the line number in the input file that triggered
    *     the failed validation status, further keyed by:
    *     - 'line_contents': The raw contents of this line that failed.
-   *
-   * @dataProvider provideValidDelimitedFileFailedCases
    */
+  #[DataProvider('provideValidDelimitedFileFailedCases')]
   public function testProcessListWithDescribedTable(array $validation_results, array $metadata, array $tokens, array $expectations) {
 
     // Process our test failures array.
@@ -625,9 +624,8 @@ class ValidatorValidDelimitedFileProcessTest extends ChadoTestKernelBase {
    *     output. It has the following keys:
    *     - 'expected_message': The message expected in the return value of the
    *       process method for this scenario.
-   *
-   * @dataProvider providePassedAndUnrecognizableCases
    */
+  #[DataProvider('providePassedAndUnrecognizableCases')]
   public function testProcessListWithDescribedTableExceptions(array $validation_results, array $metadata, array $tokens, array $expectations) {
 
     // Test with a passed validation case string.

--- a/tests/src/Kernel/Validators/ValidatorValidDelimitedFileProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidDelimitedFileProcessTest.php
@@ -410,6 +410,8 @@ class ValidatorValidDelimitedFileProcessTest extends ChadoTestKernelBase {
    *   - 1+ arrays keyed by the line number in the input file that triggered
    *     the failed validation status, further keyed by:
    *     - 'line_contents': The raw contents of this line that failed.
+   *
+   * @dataProvider provideValidDelimitedFileFailedCases
    */
   #[DataProvider('provideValidDelimitedFileFailedCases')]
   public function testProcessListWithDescribedTable(array $validation_results, array $metadata, array $tokens, array $expectations) {
@@ -627,6 +629,8 @@ class ValidatorValidDelimitedFileProcessTest extends ChadoTestKernelBase {
    *     output. It has the following keys:
    *     - 'expected_message': The message expected in the return value of the
    *       process method for this scenario.
+   *
+   * @dataProvider providePassedAndUnrecognizableCases
    */
   #[DataProvider('providePassedAndUnrecognizableCases')]
   public function testProcessListWithDescribedTableExceptions(array $validation_results, array $metadata, array $tokens, array $expectations) {

--- a/tests/src/Kernel/Validators/ValidatorValidDelimitedFileTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidDelimitedFileTest.php
@@ -4,13 +4,13 @@ namespace Drupal\Tests\trpcultivate\Kernel\Validators;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate\Traits\TripalCultivateImporterTestTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Tripal Cultivate Data File Delimited Validator Plugins.
- *
- * @group trpcultivate
- * @group validators
  */
+#[Group('trpcultivate')]
+#[Group('validators')]
 class ValidatorValidDelimitedFileTest extends ChadoTestKernelBase {
 
   use TripalCultivateImporterTestTrait;
@@ -264,9 +264,8 @@ class ValidatorValidDelimitedFileTest extends ChadoTestKernelBase {
    *   - 'case': validation test case message.
    *   - 'valid': true if validation passed, false if failed.
    *   - 'failedItems': raw row input value keyed by 'raw_row'.
-   *
-   * @dataProvider provideRawRowToDelimitedFileValidator
    */
+  #[DataProvider('provideRawRowToDelimitedFileValidator')]
   public function testDataFileRowIsDelimited(string $scenario, string $raw_row_input, $validator_config, $expected) {
     // Set validator configuration.
     $this->validator_instance->setExpectedColumns($validator_config['number_of_columns'], $validator_config['strict']);

--- a/tests/src/Kernel/Validators/ValidatorValidDelimitedFileTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidDelimitedFileTest.php
@@ -267,6 +267,8 @@ class ValidatorValidDelimitedFileTest extends ChadoTestKernelBase {
    *   - 'case': validation test case message.
    *   - 'valid': true if validation passed, false if failed.
    *   - 'failedItems': raw row input value keyed by 'raw_row'.
+   *
+   * @dataProvider provideRawRowToDelimitedFileValidator
    */
   #[DataProvider('provideRawRowToDelimitedFileValidator')]
   public function testDataFileRowIsDelimited(string $scenario, string $raw_row_input, $validator_config, $expected) {

--- a/tests/src/Kernel/Validators/ValidatorValidDelimitedFileTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidDelimitedFileTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Tripal Cultivate Data File Delimited Validator Plugins.
+ *
+ * @group trpcultivate
+ * @group validators
  */
 #[Group('trpcultivate')]
 #[Group('validators')]

--- a/tests/src/Kernel/Validators/ValidatorValidHeadersProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidHeadersProcessTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test any message process methods for the ValidHeaders validator.
+ *
+ * @group trpcultivate
+ * @group validators
  */
 #[Group('trpcultivate')]
 #[Group('validators')]

--- a/tests/src/Kernel/Validators/ValidatorValidHeadersProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidHeadersProcessTest.php
@@ -3,13 +3,13 @@
 namespace Drupal\Tests\trpcultivate\Kernel\Validators;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test any message process methods for the ValidHeaders validator.
- *
- * @group trpcultivate
- * @group validators
  */
+#[Group('trpcultivate')]
+#[Group('validators')]
 class ValidatorValidHeadersProcessTest extends ChadoTestKernelBase {
 
   /**
@@ -243,9 +243,8 @@ class ValidatorValidHeadersProcessTest extends ChadoTestKernelBase {
    *   following keys:
    *     - 'expected_message': The message expected in the return value of the
    *       process method for this scenario.
-   *
-   * @dataProvider provideValidHeadersFailedCases
    */
+  #[DataProvider('provideValidHeadersFailedCases')]
   public function testProcessListWithDescribedTableFailures(array $validation_status, array $metadata, array $tokens, array $expectations) {
 
     // Call the process method on our validation result.
@@ -406,9 +405,8 @@ class ValidatorValidHeadersProcessTest extends ChadoTestKernelBase {
    *   following keys:
    *     - 'expected_message': The exception message that is expected to be
    *       triggered.
-   *
-   * @dataProvider providePassedAndUnrecognizableCases
    */
+  #[DataProvider('providePassedAndUnrecognizableCases')]
   public function testProcessListWithDescribedTableExceptions(array $validation_status, array $metadata, array $tokens, array $expectations) {
 
     // Test with a passed validation case string.

--- a/tests/src/Kernel/Validators/ValidatorValidHeadersProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidHeadersProcessTest.php
@@ -246,6 +246,8 @@ class ValidatorValidHeadersProcessTest extends ChadoTestKernelBase {
    *   following keys:
    *     - 'expected_message': The message expected in the return value of the
    *       process method for this scenario.
+   *
+   * @dataProvider provideValidHeadersFailedCases
    */
   #[DataProvider('provideValidHeadersFailedCases')]
   public function testProcessListWithDescribedTableFailures(array $validation_status, array $metadata, array $tokens, array $expectations) {
@@ -408,6 +410,8 @@ class ValidatorValidHeadersProcessTest extends ChadoTestKernelBase {
    *   following keys:
    *     - 'expected_message': The exception message that is expected to be
    *       triggered.
+   *
+   * @dataProvider providePassedAndUnrecognizableCases
    */
   #[DataProvider('providePassedAndUnrecognizableCases')]
   public function testProcessListWithDescribedTableExceptions(array $validation_status, array $metadata, array $tokens, array $expectations) {

--- a/tests/src/Kernel/Validators/ValidatorValidHeadersTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidHeadersTest.php
@@ -4,13 +4,13 @@ namespace Drupal\Tests\trpcultivate\Kernel\Validators;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\trpcultivate\Traits\TripalCultivateImporterTestTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Tripal Cultivate Headers Validator Plugin.
- *
- * @group trpcultivate
- * @group validators
  */
+#[Group('trpcultivate')]
+#[Group('validators')]
 class ValidatorValidHeadersTest extends ChadoTestKernelBase {
 
   use TripalCultivateImporterTestTrait;
@@ -412,9 +412,8 @@ class ValidatorValidHeadersTest extends ChadoTestKernelBase {
    *   - 'number_of_columns': number of column headers to expect after splitting
    *     the line.
    *   - 'strict': indicates if number of columns must be exact.
-   *
-   * @dataProvider provideHeadersToHeadersValidator
    */
+  #[DataProvider('provideHeadersToHeadersValidator')]
   public function testHeaders(string $scenario, array $headers_input, array $expected, array $expected_columns) {
 
     $this->validator_instance->setExpectedColumns($expected_columns['number_of_columns'], $expected_columns['strict']);

--- a/tests/src/Kernel/Validators/ValidatorValidHeadersTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidHeadersTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests Tripal Cultivate Headers Validator Plugin.
+ *
+ * @group trpcultivate
+ * @group validators
  */
 #[Group('trpcultivate')]
 #[Group('validators')]

--- a/tests/src/Kernel/Validators/ValidatorValidHeadersTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValidHeadersTest.php
@@ -415,6 +415,8 @@ class ValidatorValidHeadersTest extends ChadoTestKernelBase {
    *   - 'number_of_columns': number of column headers to expect after splitting
    *     the line.
    *   - 'strict': indicates if number of columns must be exact.
+   *
+   * @dataProvider provideHeadersToHeadersValidator
    */
   #[DataProvider('provideHeadersToHeadersValidator')]
   public function testHeaders(string $scenario, array $headers_input, array $expected, array $expected_columns) {

--- a/tests/src/Kernel/Validators/ValidatorValueInListProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValueInListProcessTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test any message process methods for the ValueInList validator.
+ *
+ * @group trpcultivate
+ * @group validators
  */
 #[Group('trpcultivate')]
 #[Group('validators')]

--- a/tests/src/Kernel/Validators/ValidatorValueInListProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValueInListProcessTest.php
@@ -3,13 +3,13 @@
 namespace Drupal\Tests\trpcultivate\Kernel\Validators;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test any message process methods for the ValueInList validator.
- *
- * @group trpcultivate
- * @group validators
  */
+#[Group('trpcultivate')]
+#[Group('validators')]
 class ValidatorValueInListProcessTest extends ChadoTestKernelBase {
 
   /**
@@ -461,9 +461,8 @@ class ValidatorValueInListProcessTest extends ChadoTestKernelBase {
    *     by the column header name of a cell in this row and its value is the
    *     invalid value. For example:
    *     - 2 => [ 'Type' => 'Invalid Value' ].
-   *
-   * @dataProvider provideValueInListFailedCases
    */
+  #[DataProvider('provideValueInListFailedCases')]
   public function testProcessListWithDescribedTable(array $validation_results, array $metadata, array $tokens, array $expectations) {
 
     // Process our test failures array for this scenario.
@@ -718,9 +717,8 @@ class ValidatorValueInListProcessTest extends ChadoTestKernelBase {
    *   following keys:
    *     - 'expected_message': The exception message that is expected to be
    *       triggered.
-   *
-   * @dataProvider providePassedAndUnrecognizableCases
    */
+  #[DataProvider('providePassedAndUnrecognizableCases')]
   public function testProcessListWithDescribedTableExceptions(array $validation_results, array $metadata, array $tokens, array $expectations) {
 
     // Test with a passed validation case string.

--- a/tests/src/Kernel/Validators/ValidatorValueInListProcessTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValueInListProcessTest.php
@@ -464,6 +464,8 @@ class ValidatorValueInListProcessTest extends ChadoTestKernelBase {
    *     by the column header name of a cell in this row and its value is the
    *     invalid value. For example:
    *     - 2 => [ 'Type' => 'Invalid Value' ].
+   *
+   * @dataProvider provideValueInListFailedCases
    */
   #[DataProvider('provideValueInListFailedCases')]
   public function testProcessListWithDescribedTable(array $validation_results, array $metadata, array $tokens, array $expectations) {
@@ -720,6 +722,8 @@ class ValidatorValueInListProcessTest extends ChadoTestKernelBase {
    *   following keys:
    *     - 'expected_message': The exception message that is expected to be
    *       triggered.
+   *
+   * @dataProvider providePassedAndUnrecognizableCases
    */
   #[DataProvider('providePassedAndUnrecognizableCases')]
   public function testProcessListWithDescribedTableExceptions(array $validation_results, array $metadata, array $tokens, array $expectations) {

--- a/tests/src/Kernel/Validators/ValidatorValueInListTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValueInListTest.php
@@ -8,6 +8,10 @@ use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
 
 /**
  * Tests the Value In List validator.
+ *
+ * @group trpcultivate
+ * @group validators
+ * @group row_validators
  */
 #[Group('trpcultivate')]
 #[Group('validators')]

--- a/tests/src/Kernel/Validators/ValidatorValueInListTest.php
+++ b/tests/src/Kernel/Validators/ValidatorValueInListTest.php
@@ -8,11 +8,10 @@ use Drupal\trpcultivate\TripalCultivateValidator\TripalCultivateValidatorManager
 
 /**
  * Tests the Value In List validator.
- *
- * @group trpcultivate
- * @group validators
- * @group row_validators
  */
+#[Group('trpcultivate')]
+#[Group('validators')]
+#[Group('row_validators')]
 class ValidatorValueInListTest extends ChadoTestKernelBase {
 
   /**

--- a/tests/src/Traits/TripalCultivateImporterTestTraitTest.php
+++ b/tests/src/Traits/TripalCultivateImporterTestTraitTest.php
@@ -8,9 +8,8 @@ use Drupal\Tests\trpcultivate\Traits\TripalCultivateImporterTestTrait;
 
 /**
  * Test importer test trait.
- *
- * @group trpcultivate_test_trait
  */
+#[Group('trpcultivatw_test_trait')]
 class TripalCultivateImporterTestTraitTest extends ChadoTestKernelBase {
 
   use TripalCultivateImporterTestTrait;

--- a/tests/src/Traits/TripalCultivateImporterTestTraitTest.php
+++ b/tests/src/Traits/TripalCultivateImporterTestTraitTest.php
@@ -11,7 +11,7 @@ use Drupal\Tests\trpcultivate\Traits\TripalCultivateImporterTestTrait;
  *
  * @group trpcultivate_test_trait
  */
-#[Group('trpcultivatw_test_trait')]
+#[Group('trpcultivate_test_trait')]
 class TripalCultivateImporterTestTraitTest extends ChadoTestKernelBase {
 
   use TripalCultivateImporterTestTrait;

--- a/tests/src/Traits/TripalCultivateImporterTestTraitTest.php
+++ b/tests/src/Traits/TripalCultivateImporterTestTraitTest.php
@@ -8,6 +8,8 @@ use Drupal\Tests\trpcultivate\Traits\TripalCultivateImporterTestTrait;
 
 /**
  * Test importer test trait.
+ *
+ * @group trpcultivate_test_trait
  */
 #[Group('trpcultivatw_test_trait')]
 class TripalCultivateImporterTestTraitTest extends ChadoTestKernelBase {


### PR DESCRIPTION
**Issue #77**

## Motivation
<!-- This can usually be copied from the issue.
     Please do not just say, go see issue but instead
    copy the relevant details here. -->
Drupal is migrating its plugin discovery mechanism from Annotations to PHP Attributes, particularly Drupal 10.2 and newer versions. This change is in alignment with Symfony and PHP 8 best practices. We are currently using Doctrine annotations (eg. @TripalCultivateValidator) for metadata declarations. These should be migrated to PHP 8 attributes to ensure forward compatibility.

## What does this PR do?
<!-- Please describe each things this PR does.
     For example, a PR may 1) solve a specific bug,
     2) create an automated test to ensure it doesn't return. -->

- [x] Adds the attribute object for the TripalCultivateValidator


Update the following annotations to attributes:
- [x] TripalCultivateValidator
- [x] Group
- [x] Data Provider
- [x] TripalImporter

## Testing

### Automated Testing
 <!-- Please describe each automated test this PR creates
     and provide a list of the assertions it makes using casual language.
     Do not just say things like "asserts the array is not empty"
     but rather say "Ensures that the return value of method X
     with these parameters is not an empty array". -->

There are no new automated testing for this PR; however, all the automated tests should pass with drupal 11.1.x.


### Manual Testing
<!-- Describe in detail how someone should manually test this functionality.
     Make sure to include whether they need to build a docker from scratch,
     create any records, configure anything, etc. -->

1. Start a fresh docker image/container on this branch. **You can use the devcontainer approach OR the following commands:**
  ```
  cd ~/Dockers
  git clone https://github.com/TripalCultivate/TripalCultivate g4.71-MigrateFromAnnotationsToAttributes
  cd g4.71-MigrateFromAnnotationsToAttributes
  git checkout g4.71-MigrateFromAnnotationsToAttributes
  docker build --tag=trpcultivate-base:review78 ./
  docker run --publish=80:80 -tid --name=base78 --volume=`pwd`:/var/www/drupal/web/modules/contrib/TripalCultivate trpcultivate-base:review78
  ```
2. Create a duplicate copy of the Test Importer by copying the directory and pasting it in src/Plugins
3. Save Changes and clear cache.

The Test Importer should appear without any errors on the when navigated to Tripal > Data Loaders.
