### PR TITLE
Update base image to support PHP 8.4, exclude Drupal 11.0.x

### DIFF
--- a/.github/workflows/MAIN-buildTripalDocker.yml
+++ b/.github/workflows/MAIN-buildTripalDocker.yml
@@ -20,6 +20,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         pgsql-version:
           - "13"
           - "14"
@@ -29,15 +30,16 @@ jobs:
         drupal-version:
           - "10.4.x-dev"
           - "10.5.x-dev"
-          - "11.0.x-dev"
           - "11.1.x-dev"
           - "11.x-dev"
           - "11.2.x-dev"
         exclude:
-          - php-version: "8.1"
-            drupal-version: "11.0.x-dev"
-          - php-version: "8.2"
-            drupal-version: "11.0.x-dev"
+          ## Only Drupal 11.x supports PHP 8.4
+          - php-version: '8.4'
+            drupal-version: '10.4.x-dev'
+          - php-version: '8.4'
+            drupal-version: '10.5.x-dev'
+          ## Drupal 11.x requires PHP 8.3+
           - php-version: "8.1"
             drupal-version: "11.1.x-dev"
           - php-version: "8.2"
@@ -50,12 +52,7 @@ jobs:
             drupal-version: "11.2.x-dev"
           - php-version: "8.2"
             drupal-version: "11.2.x-dev"
-          - pgsql-version: "13"
-            drupal-version: "11.0.x-dev"
-          - pgsql-version: "14"
-            drupal-version: "11.0.x-dev"
-          - pgsql-version: "15"
-            drupal-version: "11.0.x-dev"
+          ## Drupal 11.x requires PostgreSQL 16+
           - pgsql-version: "13"
             drupal-version: "11.1.x-dev"
           - pgsql-version: "14"


### PR DESCRIPTION
**Issue #88**

## Motivation
This is the mini PR mentioned in step 1 of Issue #88. By doing this in its own PR, these docker images will become available for the next step.

Tripal core now fully supports PHP 8.4 when used with Drupal 11.x. We need to ensure that our modules also support PHP 8.4, but also need to end this module's support for Drupal 11.0.x.

## What does this PR do?
Updates [MAIN-buildTripalDocker.yml](https://github.com/TripalCultivate/TripalCultivate/blob/4.x/.github/workflows/MAIN-buildTripalDocker.yml) to:
- [x] build using PHP 8.4 with Drupal 11.1.x, 11.2.x and 11.x
- [x] remove builds that include Drupal 11.0.x

## Testing
Don't think this is possible to test, so please review the code carefully! 🙈 