### PR TITLE
G0.88 Update testing matrix to include PHP 8.4, exclude Drupal 11.0.x

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -3,12 +3,12 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      "drupalversion": "11.2.x-dev",
-      "phpversion": "8.3",
-      "pgsqlversion": "16"
+      "drupalversion": "11.x-dev",
+      "phpversion": "8.4",
+      "pgsqlversion": "17"
     }
   },
-  "initializeCommand": "docker pull knowpulse/tripalcultivate-tripal:drupal11.2.x-dev-php8.3-pgsql16",
+  "initializeCommand": "docker pull knowpulse/tripalcultivate-tripal:drupal11.x-dev-php8.4-pgsql17",
   "workspaceMount": "source=${localWorkspaceFolder},target=/var/www/drupal/web/modules/contrib/TripalCultivate,type=bind",
   "workspaceFolder": "/var/www/drupal/web/modules/contrib/TripalCultivate",
   "customizations": {

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -29,23 +29,35 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         pgsql-version:
           - "13"
-          - "16"
+          - "17"
         drupal-version:
           - "10.4.x-dev"
           - "10.5.x-dev"
-          - "11.0.x-dev"
           - "11.1.x-dev"
           - "11.2.x-dev"
         exclude:
-          - php-version: "8.1"
-            drupal-version: "11.0.x-dev"
-          - php-version: "8.2"
-            drupal-version: "11.0.x-dev"
-          - php-version: "8.3"
-            pgsql-version: "13"
-            drupal-version: "11.0.x-dev"
+          # Only Drupal 11.x supports PHP 8.4.
+          - php-version: '8.4'
+            drupal-version: '10.4.x-dev'
+          - php-version: '8.4'
+            drupal-version: '10.5.x-dev'
+          # Drupal 11+ requires at least Postgresql 16.
+          - php-version: '8.3'
+            pgsql-version: '13'
+            drupal-version: '11.1.x-dev'
+          - php-version: '8.4'
+            pgsql-version: '13'
+            drupal-version: '11.1.x-dev'
+          - php-version: '8.3'
+            pgsql-version: '13'
+            drupal-version: '11.2.x-dev'
+          - php-version: '8.4'
+            pgsql-version: '13'
+            drupal-version: '11.2.x-dev'
+          # Drupal 11+ requires at least php 8.3.
           - php-version: "8.1"
             drupal-version: "11.1.x-dev"
           - php-version: "8.2"

--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -38,6 +38,7 @@ jobs:
           - "10.5.x-dev"
           - "11.1.x-dev"
           - "11.2.x-dev"
+          - "11.x-dev"
         exclude:
           # Only Drupal 11.x supports PHP 8.4.
           - php-version: '8.4'
@@ -57,6 +58,12 @@ jobs:
           - php-version: '8.4'
             pgsql-version: '13'
             drupal-version: '11.2.x-dev'
+          - php-version: '8.3'
+            pgsql-version: '13'
+            drupal-version: '11.x-dev'
+          - php-version: '8.4'
+            pgsql-version: '13'
+            drupal-version: '11.x-dev'
           # Drupal 11+ requires at least php 8.3.
           - php-version: "8.1"
             drupal-version: "11.1.x-dev"
@@ -66,6 +73,10 @@ jobs:
             drupal-version: "11.2.x-dev"
           - php-version: "8.2"
             drupal-version: "11.2.x-dev"
+          - php-version: "8.1"
+            drupal-version: "11.x-dev"
+          - php-version: "8.2"
+            drupal-version: "11.x-dev"
 
     steps:
       # Check out the repo

--- a/.github/workflows/ALL-testCoverage-qltycloud.yml
+++ b/.github/workflows/ALL-testCoverage-qltycloud.yml
@@ -7,7 +7,7 @@ on: [push, workflow_dispatch]
 
 jobs:
   run-coverage:
-    name: "Drupal 11.1.x-dev - PHP 8.3 - PostgreSQL 16"
+    name: "Drupal 11.1.x-dev - PHP 8.4 - PostgreSQL 17"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -19,7 +19,7 @@ jobs:
           modules: 'trpcultivate'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: 8.3
-          pgsql-version: 16
+          php-version: 8.4
+          pgsql-version: 17
           drupal-version: 11.1.x-dev
           qltycloud-reporter-id: ${{ secrets.QLTY_COVERAGE_TOKEN }}

--- a/.github/workflows/MAIN-buildDocker.yml
+++ b/.github/workflows/MAIN-buildDocker.yml
@@ -23,6 +23,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         pgsql-version:
           - "13"
           - "14"
@@ -32,33 +33,29 @@ jobs:
         drupal-version:
           - "10.4.x-dev"
           - "10.5.x-dev"
-          - "11.0.x-dev"
           - "11.1.x-dev"
-          - "11.x-dev"
           - "11.2.x-dev"
+          - "11.x-dev"
         exclude:
-          - php-version: "8.1"
-            drupal-version: "11.0.x-dev"
-          - php-version: "8.2"
-            drupal-version: "11.0.x-dev"
+          ## Only Drupal 11.x supports PHP 8.4.
+          - php-version: '8.4'
+            drupal-version: '10.4.x-dev'
+          - php-version: '8.4'
+            drupal-version: '10.5.x-dev'
+          ## Drupal 11.x requires PHP 8.3+.
           - php-version: "8.1"
             drupal-version: "11.1.x-dev"
           - php-version: "8.2"
             drupal-version: "11.1.x-dev"
           - php-version: "8.1"
-            drupal-version: "11.x-dev"
+            drupal-version: "11.2.x-dev"
           - php-version: "8.2"
-            drupal-version: "11.x-dev"
+            drupal-version: "11.2.x-dev"
           - php-version: "8.1"
-            drupal-version: "11.2.x-dev"
+            drupal-version: "11.x-dev"
           - php-version: "8.2"
-            drupal-version: "11.2.x-dev"
-          - pgsql-version: "13"
-            drupal-version: "11.0.x-dev"
-          - pgsql-version: "14"
-            drupal-version: "11.0.x-dev"
-          - pgsql-version: "15"
-            drupal-version: "11.0.x-dev"
+            drupal-version: "11.x-dev"
+          ## Drupal 11.x requires PostgreSQL 16+.
           - pgsql-version: "13"
             drupal-version: "11.1.x-dev"
           - pgsql-version: "14"
@@ -66,17 +63,17 @@ jobs:
           - pgsql-version: "15"
             drupal-version: "11.1.x-dev"
           - pgsql-version: "13"
-            drupal-version: "11.x-dev"
+            drupal-version: "11.2.x-dev"
           - pgsql-version: "14"
-            drupal-version: "11.x-dev"
+            drupal-version: "11.2.x-dev"
           - pgsql-version: "15"
-            drupal-version: "11.x-dev"
+            drupal-version: "11.2.x-dev"
           - pgsql-version: "13"
-            drupal-version: "11.2.x-dev"
+            drupal-version: "11.x-dev"
           - pgsql-version: "14"
-            drupal-version: "11.2.x-dev"
+            drupal-version: "11.x-dev"
           - pgsql-version: "15"
-            drupal-version: "11.2.x-dev"
+            drupal-version: "11.x-dev"
     name: TripalCultivate ${{ matrix.drupal-version }}-php${{ matrix.php-version }}-pgsql${{ matrix.pgsql-version }}
     steps:
       - uses: actions/checkout@v4
@@ -102,8 +99,8 @@ jobs:
           buildArgs: "drupalversion=${{ matrix.drupal-version }},phpversion=${{ matrix.php-version }},pgsqlversion=${{ matrix.pgsql-version }},installTheme='notheme-'"
           labels: 'drupal.version.label="${{ matrix.drupal-version }}",php.version.label="${{ matrix.php-version }}", postgresql.version.label="${{ matrix.pgsql-version }}"'
       - uses: mr-smithers-excellent/docker-build-push@v6.5
-        name: Build baseonly-latest using 11.2.x-dev, PHP 8.3, PgSQL 17
-        if: ${{ matrix.drupal-version == '11.2.x-dev' && matrix.php-version == '8.3' && matrix.pgsql-version == '17' }}
+        name: Build baseonly-latest using 11.2.x-dev, PHP 8.4, PgSQL 17
+        if: ${{ matrix.drupal-version == '11.2.x-dev' && matrix.php-version == '8.4' && matrix.pgsql-version == '17' }}
         with:
           image: knowpulse/tripalcultivate-base
           tags: latest

--- a/.github/workflows/MAIN-phpunit-Grid1A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1A.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - g0.81-support11.2
+      - g0.88-updateTestingMatrix
   # Allows us to manually trigger this workflow.
   # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
   workflow_dispatch:
@@ -15,15 +15,16 @@ on:
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters
-## |  Drupal     |  10.4.x         |  10.5.x         |  11.0.x         | 11.1.x          | 11.2.x          |
-## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
-## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |                 |
-## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |                 |
-## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
+## |  Drupal     |  10.4.x         |  10.5.x         |  11.1.x         | 11.2.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] |
+## | **PHP 8.4** |                 |                 | ![Grid3D-Badge] | ![Grid4D-Badge] |
 
 jobs:
   grid-1A:
-    name: "Drupal 10.4.x-dev - PHP 8.1 - PostgreSQL 16"
+    name: "Drupal 10.4.x-dev - PHP 8.1 - PostgreSQL 17"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -36,5 +37,5 @@ jobs:
           build-image: TRUE
           dockerfile: 'Dockerfile'
           php-version: '8.1'
-          pgsql-version: '16'
+          pgsql-version: '17'
           drupal-version: '10.4.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid1C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid1C.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - g0.81-support11.2
+      - g0.88-updateTestingMatrix
   # Allows us to manually trigger this workflow.
   # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
   workflow_dispatch:
@@ -15,15 +15,16 @@ on:
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters
-## |  Drupal     |  10.4.x         |  10.5.x         |  11.0.x         | 11.1.x          | 11.2.x          |
-## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
-## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |                 |
-## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |                 |
-## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
+## |  Drupal     |  10.4.x         |  10.5.x         |  11.1.x         | 11.2.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] |
+## | **PHP 8.4** |                 |                 | ![Grid3D-Badge] | ![Grid4D-Badge] |
 
 jobs:
   grid-1C:
-    name: "Drupal 10.4.x-dev - PHP 8.3 - PostgreSQL 16"
+    name: "Drupal 10.4.x-dev - PHP 8.3 - PostgreSQL 17"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -36,5 +37,5 @@ jobs:
           build-image: TRUE
           dockerfile: 'Dockerfile'
           php-version: '8.3'
-          pgsql-version: '16'
+          pgsql-version: '17'
           drupal-version: '10.4.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2A.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2A.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - g0.81-support11.2
+      - g0.88-updateTestingMatrix
   # Allows us to manually trigger this workflow.
   # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
   workflow_dispatch:
@@ -15,15 +15,16 @@ on:
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters
-## |  Drupal     |  10.4.x         |  10.5.x         |  11.0.x         | 11.1.x          | 11.2.x          |
-## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
-## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |                 |
-## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |                 |
-## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
+## |  Drupal     |  10.4.x         |  10.5.x         |  11.1.x         | 11.2.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] |
+## | **PHP 8.4** |                 |                 | ![Grid3D-Badge] | ![Grid4D-Badge] |
 
 jobs:
   grid-2A:
-    name: "Drupal 10.5.x-dev - PHP 8.1 - PostgreSQL 16"
+    name: "Drupal 10.5.x-dev - PHP 8.1 - PostgreSQL 17"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -36,5 +37,5 @@ jobs:
           build-image: TRUE
           dockerfile: 'Dockerfile'
           php-version: '8.1'
-          pgsql-version: '16'
+          pgsql-version: '17'
           drupal-version: '10.5.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2B.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2B.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - g0.81-support11.2
+      - g0.88-updateTestingMatrix
   # Allows us to manually trigger this workflow.
   # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
   workflow_dispatch:
@@ -15,15 +15,16 @@ on:
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters
-## |  Drupal     |  10.4.x         |  10.5.x         |  11.0.x         | 11.1.x          | 11.2.x          |
-## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
-## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |                 |
-## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |                 |
-## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
+## |  Drupal     |  10.4.x         |  10.5.x         |  11.1.x         | 11.2.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] |
+## | **PHP 8.4** |                 |                 | ![Grid3D-Badge] | ![Grid4D-Badge] |
 
 jobs:
   grid-2B:
-    name: "Drupal 10.5.x-dev - PHP 8.2 - PostgreSQL 16"
+    name: "Drupal 10.5.x-dev - PHP 8.2 - PostgreSQL 17"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -36,5 +37,5 @@ jobs:
           build-image: TRUE
           dockerfile: 'Dockerfile'
           php-version: '8.2'
-          pgsql-version: '16'
+          pgsql-version: '17'
           drupal-version: '10.5.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid2C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid2C.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - g0.81-support11.2
+      - g0.88-updateTestingMatrix
   # Allows us to manually trigger this workflow.
   # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
   workflow_dispatch:
@@ -15,15 +15,16 @@ on:
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters
-## |  Drupal     |  10.4.x         |  10.5.x         |  11.0.x         | 11.1.x          | 11.2.x          |
-## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
-## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |                 |
-## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |                 |
-## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
+## |  Drupal     |  10.4.x         |  10.5.x         |  11.1.x         | 11.2.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] |
+## | **PHP 8.4** |                 |                 | ![Grid3D-Badge] | ![Grid4D-Badge] |
 
 jobs:
   grid-2C:
-    name: "Drupal 10.5.x-dev - PHP 8.3 - PostgreSQL 16"
+    name: "Drupal 10.5.x-dev - PHP 8.3 - PostgreSQL 17"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -36,5 +37,5 @@ jobs:
           build-image: TRUE
           dockerfile: 'Dockerfile'
           php-version: '8.3'
-          pgsql-version: '16'
+          pgsql-version: '17'
           drupal-version: '10.5.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid3C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3C.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - g0.81-support11.2
+      - g0.88-updateTestingMatrix
   # Allows us to manually trigger this workflow.
   # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
   workflow_dispatch:
@@ -15,15 +15,16 @@ on:
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters
-## |  Drupal     |  10.4.x         |  10.5.x         |  11.0.x         | 11.1.x          | 11.2.x          |
-## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
-## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |                 |
-## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |                 |
-## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
+## |  Drupal     |  10.4.x         |  10.5.x         |  11.1.x         | 11.2.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] |
+## | **PHP 8.4** |                 |                 | ![Grid3D-Badge] | ![Grid4D-Badge] |
 
 jobs:
   grid-3C:
-    name: "Drupal 11.0.x-dev - PHP 8.3 - PostgreSQL 16"
+    name: "Drupal 11.1.x-dev - PHP 8.3 - PostgreSQL 17"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -36,5 +37,5 @@ jobs:
           build-image: TRUE
           dockerfile: 'Dockerfile'
           php-version: '8.3'
-          pgsql-version: '16'
-          drupal-version: '11.0.x-dev'
+          pgsql-version: '17'
+          drupal-version: '11.1.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid3D.yml
+++ b/.github/workflows/MAIN-phpunit-Grid3D.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - g0.81-support11.2
+      - g0.88-updateTestingMatrix
   # Allows us to manually trigger this workflow.
   # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
   workflow_dispatch:
@@ -15,15 +15,16 @@ on:
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters
-## |  Drupal     |  10.4.x         |  10.5.x         |  11.0.x         | 11.1.x          | 11.2.x          |
-## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
-## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |                 |
-## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |                 |
-## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
+## |  Drupal     |  10.4.x         |  10.5.x         |  11.1.x         | 11.2.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] |
+## | **PHP 8.4** |                 |                 | ![Grid3D-Badge] | ![Grid4D-Badge] |
 
 jobs:
-  grid-3C:
-    name: "Drupal 11.2.x-dev - PHP 8.3 - PostgreSQL 16"
+  grid-3D:
+    name: "Drupal 11.1.x-dev - PHP 8.4 - PostgreSQL 17"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -35,6 +36,6 @@ jobs:
           modules: 'trpcultivate'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.3'
-          pgsql-version: '16'
-          drupal-version: '11.2.x-dev'
+          php-version: '8.4'
+          pgsql-version: '17'
+          drupal-version: '11.1.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid4C.yml
+++ b/.github/workflows/MAIN-phpunit-Grid4C.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 4.x
-      - g0.81-support11.2
+      - g0.88-updateTestingMatrix
   # Allows us to manually trigger this workflow.
   # This is great if there is a change made to Tripal core that we want to test our modules on ASAP.
   workflow_dispatch:
@@ -15,15 +15,16 @@ on:
 
 ## UPDATES
 ## Update the version numbers in the job name and the action parameters
-## |  Drupal     |  10.4.x         |  10.5.x         |  11.0.x         | 11.1.x          | 11.2.x          |
-## |-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
-## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |                 |
-## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |                 |
-## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
+## |  Drupal     |  10.4.x         |  10.5.x         |  11.1.x         | 11.2.x          |
+## |-------------|-----------------|-----------------|-----------------|-----------------|
+## | **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |
+## | **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |
+## | **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] |
+## | **PHP 8.4** |                 |                 | ![Grid3D-Badge] | ![Grid4D-Badge] |
 
 jobs:
-  grid-3C:
-    name: "Drupal 11.1.x-dev - PHP 8.3 - PostgreSQL 16"
+  grid-4C:
+    name: "Drupal 11.2.x-dev - PHP 8.3 - PostgreSQL 17"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -36,5 +37,5 @@ jobs:
           build-image: TRUE
           dockerfile: 'Dockerfile'
           php-version: '8.3'
-          pgsql-version: '16'
-          drupal-version: '11.1.x-dev'
+          pgsql-version: '17'
+          drupal-version: '11.2.x-dev'

--- a/.github/workflows/MAIN-phpunit-Grid4D.yml
+++ b/.github/workflows/MAIN-phpunit-Grid4D.yml
@@ -23,8 +23,8 @@ on:
 ## | **PHP 8.4** |                 |                 | ![Grid3D-Badge] | ![Grid4D-Badge] |
 
 jobs:
-  grid-1B:
-    name: "Drupal 10.4.x-dev - PHP 8.2 - PostgreSQL 17"
+  grid-4D:
+    name: "Drupal 11.2.x-dev - PHP 8.4 - PostgreSQL 17"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -36,6 +36,6 @@ jobs:
           modules: 'trpcultivate'
           build-image: TRUE
           dockerfile: 'Dockerfile'
-          php-version: '8.2'
+          php-version: '8.4'
           pgsql-version: '17'
-          drupal-version: '10.4.x-dev'
+          drupal-version: '11.2.x-dev'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 supervisord*
 .phpunit.result.cache
+.phpunit.cache
 composer.lock
 *.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG drupalversion=11.2.x-dev
-ARG phpversion=8.3
-ARG pgsqlversion=16
+ARG phpversion=8.4
+ARG pgsqlversion=17
 ARG installTheme
 FROM knowpulse/tripalcultivate-tripal:${installTheme}drupal${drupalversion}-php${phpversion}-pgsql${pgsqlversion}
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ maintainability issues and test coverage.
 
 The following compatibility is proven via automated testing workflows.
 
-|  Drupal     |  10.4.x         |  10.5.x         | 11.0.x          | 11.1.x          |  11.2.x
-|-------------|-----------------|-----------------|-----------------|-----------------|-----------------|
-| **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |                 |
-| **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |                 |
-| **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] | ![Grid5C-Badge] |
+|  Drupal     |  10.4.x         |  10.5.x         |  11.1.x         | 11.2.x          |
+|-------------|-----------------|-----------------|-----------------|-----------------|
+| **PHP 8.1** | ![Grid1A-Badge] | ![Grid2A-Badge] |                 |                 |
+| **PHP 8.2** | ![Grid1B-Badge] | ![Grid2B-Badge] |                 |                 |
+| **PHP 8.3** | ![Grid1C-Badge] | ![Grid2C-Badge] | ![Grid3C-Badge] | ![Grid4C-Badge] |
+| **PHP 8.4** |                 |                 | ![Grid3D-Badge] | ![Grid4D-Badge] |
 
 
 [our QLTY Cloud project page]: https://qlty.sh/gh/TripalCultivate/projects/TripalCultivate
@@ -66,7 +67,7 @@ The following compatibility is proven via automated testing workflows.
 [Grid2C-Badge]: https://github.com/TripalCultivate/TripalCultivate/actions/workflows/MAIN-phpunit-Grid2C.yml/badge.svg
 
 [Grid3C-Badge]: https://github.com/TripalCultivate/TripalCultivate/actions/workflows/MAIN-phpunit-Grid3C.yml/badge.svg
+[Grid3D-Badge]: https://github.com/TripalCultivate/TripalCultivate/actions/workflows/MAIN-phpunit-Grid3D.yml/badge.svg
 
 [Grid4C-Badge]: https://github.com/TripalCultivate/TripalCultivate/actions/workflows/MAIN-phpunit-Grid4C.yml/badge.svg
-
-[Grid5C-Badge]: https://github.com/TripalCultivate/TripalCultivate/actions/workflows/MAIN-phpunit-Grid5C.yml/badge.svg
+[Grid4D-Badge]: https://github.com/TripalCultivate/TripalCultivate/actions/workflows/MAIN-phpunit-Grid4D.yml/badge.svg

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,26 +4,14 @@
  or your current system user. See core/tests/README.md and
  https://www.drupal.org/node/2116263 for details.
 -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="../../../core/tests/bootstrap.php" colors="true"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutChangesToGlobalState="true"
-         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src</directory>
-      <file>trpcultivate.module</file>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../../core/tests/bootstrap.php" colors="true" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutOutputDuringTests="true" beStrictAboutChangesToGlobalState="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <php>
     <!-- Set error reporting to E_ALL. -->
     <ini name="error_reporting" value="32767"/>
     <!-- Do not limit the amount of memory tests take to run. -->
     <ini name="memory_limit" value="-1"/>
     <!-- Stop specific phpunit deprecation notices that Drupal or Symphony cause. -->
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
     <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
     <env name="SIMPLETEST_BASE_URL" value="http://localhost"/>
     <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
@@ -52,8 +40,10 @@
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <listeners>
-    <listener class="\Drupal\Tests\Listeners\DrupalListener">
-    </listener>
-  </listeners>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+      <file>trpcultivate.module</file>
+    </include>
+  </source>
 </phpunit>

--- a/src/Service/ImportValidationHelper.php
+++ b/src/Service/ImportValidationHelper.php
@@ -228,7 +228,7 @@ class ImportValidationHelper {
    *   - The value for 'failedItems' is not an array.
    *   - The value for 'failedItems' is an empty array.
    */
-  public static function checkValidationStatusArray(array $validation_result, string $validator_name, int|null $line_no = NULL) {
+  public static function checkValidationStatusArray(array $validation_result, string $validator_name, ?int $line_no = NULL) {
 
     $error_message = '';
     $errors_found = 0;

--- a/src/Service/ImportValidationHelper.php
+++ b/src/Service/ImportValidationHelper.php
@@ -143,7 +143,7 @@ class ImportValidationHelper {
     // If there is only one supported delimiter then simply split the row!
     if (count($supported_delimiters) === 1) {
       $delimiter = end($supported_delimiters);
-      $columns = str_getcsv($row, $delimiter);
+      $columns = str_getcsv($row, separator: $delimiter, escape: "\\");
     }
 
     // @todo Address in issue #118.

--- a/tests/src/Kernel/ImplementedHooksTest.php
+++ b/tests/src/Kernel/ImplementedHooksTest.php
@@ -119,7 +119,7 @@ class ImplementedHooksTest extends ChadoTestKernelBase {
       ->getMock();
     $routeMatchMock->expects($this->any())
       ->method('getRouteName')
-      ->will($this->returnValue($route_name));
+      ->willReturn($route_name);
     $this->container->set('current_route_match', $routeMatchMock);
 
     // Now call our preprocess hook.

--- a/tripal.Dockerfile
+++ b/tripal.Dockerfile
@@ -1,6 +1,6 @@
 ARG drupalversion=11.2.x-dev
-ARG phpversion=8.3
-ARG pgsqlversion=16
+ARG phpversion=8.4
+ARG pgsqlversion=17
 FROM tripalproject/tripaldocker:drupal${drupalversion}-php${phpversion}-pgsql${pgsqlversion}-noChado
 
 ARG chadoschema='testchado'

--- a/trpcultivate.info.yml
+++ b/trpcultivate.info.yml
@@ -2,7 +2,7 @@ name: "Base API"
 type: module
 description: Provides basic functionality shared by the entire Tripal Cultivate package of modules.
 package: "Tripal Cultivate"
-core_version_requirement: ^10.4 | ^11
+core_version_requirement: ^10.4 | ^11.1
 dependencies:
   - "markup:markup"
   - "tripal:tripal"


### PR DESCRIPTION
**Issue #88**

## Motivation
This PR does step 2, 3 and 4 of Issue https://github.com/TripalCultivate/TripalCultivate/issues/88. Step 1 was completed by PR #89.

Tripal core now fully supports PHP 8.4 when used with Drupal 11.x. We need to ensure that our modules also support PHP 8.4, but also need to end this module's support for Drupal 11.0.x.

## What does this PR do?
- [x] Updates remaining workflows to include testing PHP 8.4 with Drupal 11.1.x, 11.2.x and 11.x (note removal of 11.0.x).
   - [x] It was also noticed that workflows in the testing grid were being run on PostgreSQL 16, and this has been upgraded to PostgreSQL 17.
- [x] Updates the testing grid to reflect these new test combinations.
- [x] Updates `All-PHPUnit.yml` to include Drupal 11.x-dev automatically in running tests for PRs. (commit https://github.com/TripalCultivate/TripalCultivate/pull/90/commits/09b7599b1a856c5165fa734b8f3f3f4d488c7557)
- [x] Fixes any issues brought to light by failing tests on the PHP 8.4 runs. (See issue for an example from Tripal core)
   - [x] `checkValidationStatusArray()` was updated to meet PHP 8.4 requirements by explicitly setting $line_no param as nullable (commit https://github.com/TripalCultivate/TripalCultivate/pull/90/commits/83d22d8e47b302843efd4cc908cd9391ac645f40)
   - [x] Use of `str_getcsv()` in method `splitRowUntoColumns()` requires the $escape parameter to be provided as its default value will change. (commit https://github.com/TripalCultivate/TripalCultivate/pull/90/commits/b824fe05ee41ca8645ba3b7c7a44ab4ad21d9398)
- [x] Fixes an upcoming PHPUnit 12 deprecation: Use $double->willReturn() instead of $double->will($this->returnValue()) in method `testPreprocessPage()` (commit https://github.com/TripalCultivate/TripalCultivate/pull/90/commits/b824fe05ee41ca8645ba3b7c7a44ab4ad21d9398)
- [x] Migrated `phpunit.xml` to the latest version by running the `phpunit --migrate-configuration` command (commit https://github.com/TripalCultivate/TripalCultivate/pull/90/commits/509ab29995c697f6c48599a285b0e2a81159929e)

## Testing
### Automated Testing
This PR does not add any automated tests.

### Manual Testing
- [ ] Check the automated workflows that they are being run (and passing!) on:
   - PHP 8.1, 8.2, 8.3 & 8.4
   - PostgreSQL 13 & 17
   - Drupal 10.4, 10.5, 11.1, 11.2 and 11.x, but NOT Drupal 11.0.
- [ ] Clone this branch locally in a Docker container, and make sure the container builds properly.
- [ ] Login to the site built by this container and check that it is on the latest version of everything (Drupal 11.3-dev, PHP 8.4.14, PostgreSQL 17.6) at Admin > Reports > Status report 
- [ ] Check the README on this branch and confirm the testing grid renders properly with its badges: https://github.com/TripalCultivate/TripalCultivate/tree/g0.88-updateTestingMatrix

