### PR TITLE
Update PHP and PostgreSQL version exclusions

### DIFF
--- a/.github/workflows/ALL-PHPUnit.yml
+++ b/.github/workflows/ALL-PHPUnit.yml
@@ -36,11 +36,6 @@ jobs:
           - "11.3.x-dev"
           - "11.x-dev"
         exclude:
-          # Only Drupal 11.x supports PHP 8.4
-          - php-version: '8.4'
-            drupal-version: '10.5.x-dev'
-          - php-version: '8.4'
-            drupal-version: '10.6.x-dev'
           # Only Drupal 11.3+ supports PHP 8.5.
           - php-version: "8.5"
             drupal-version: "10.5.x-dev"
@@ -71,7 +66,7 @@ jobs:
             drupal-version: '11.x-dev'
           # Exclude higher postgresql version from middle Drupal versions
           - pgsql-version: "18"
-            drupal-version: "10.5.x-dev"
+            drupal-version: "10.6.x-dev"
           # Drupal 11+ requires at least php 8.3.
           - php-version: "8.2"
             drupal-version: "11.2.x-dev"


### PR DESCRIPTION
Removed exclusions for PHP 8.4 with Drupal 10.5.x and 10.6.x. Updated PostgreSQL version for Drupal 10.5.x to 10.6.x.

We still don't have the versions quite right. No review required.