### PR TITLE
Remove username from tripal command

### DIFF
--- a/tripal.Dockerfile
+++ b/tripal.Dockerfile
@@ -39,9 +39,9 @@ RUN service postgresql start \
 
 RUN service postgresql start \
   && drush trp-prep-chado --schema-name=${chadoschema} \
-  && drush tripal:trp-import-types --username=drupaladmin --collection_id=general_chado \
-  && drush tripal:trp-import-types --username=drupaladmin --collection_id=germplasm_chado \
-  && drush tripal:trp-import-types --username=drupaladmin --collection_id=genomic_chado \
-  && drush tripal:trp-import-types --username=drupaladmin --collection_id=genetic_chado \
+  && drush tripal:trp-import-types --collection_id=general_chado \
+  && drush tripal:trp-import-types --collection_id=germplasm_chado \
+  && drush tripal:trp-import-types --collection_id=genomic_chado \
+  && drush tripal:trp-import-types --collection_id=genetic_chado \
   && drush cr \
   && service postgresql stop


### PR DESCRIPTION
**Issue #108**

## Motivation

We need some recent changes in Tripal core but the tripal docker build was failing. This PR will fixed this.

## What does this PR do?
<!-- Please describe each things this PR does.
     For example, a PR may 1) solve a specific bug,
     2) create an automated test to ensure it doesn't return. -->

- [x] Remove `--username` from `drush tripal:trp-import-types` command.

## Testing

No manual testing needed.

Instead you can see in [this run](https://github.com/TripalCultivate/TripalCultivate/actions/runs/22643087863/job/65624017751) that building the tripal docker image was failing on 4.x.

```
> [8/8] RUN service postgresql start   && drush trp-prep-chado --schema-name=testchado   && drush tripal:trp-import-types --username=drupaladmin --collection_id=general_chado   && drush tripal:trp-import-types --username=drupaladmin --collection_id=germplasm_chado   && drush tripal:trp-import-types --username=drupaladmin --collection_id=genomic_chado   && drush tripal:trp-import-types --username=drupaladmin --collection_id=genetic_chado   && drush cr   && service postgresql stop:
Notice: 17.76  [notice] Updating the cv_root_mview materialized view...
Notice: 17.77  [notice] Updating the db2cv_mview materialized view...
Notice: 17.78  [notice] Populating materialized view cv_root_mview...
Notice: 17.80  [notice] Populating materialized view db2cv_mview...
Notice: 17.82  [notice] Preparation complete.
18.12 
18.12                                            
18.12   The "--username" option does not exist.  
18.12                                            
18.12 
```

But then on this branch, building the tripal docker image now works as shown in [this run](https://github.com/TripalCultivate/TripalCultivate/actions/runs/22643655650/job/65625975071).

```
#13 [8/8] RUN service postgresql start   && drush trp-prep-chado --schema-name=testchado   && drush tripal:trp-import-types --collection_id=general_chado   && drush tripal:trp-import-types --collection_id=germplasm_chado   && drush tripal:trp-import-types --collection_id=genomic_chado   && drush tripal:trp-import-types --collection_id=genetic_chado   && drush cr   && service postgresql stop
#13 0.168 Starting PostgreSQL 18 database server: main.
#13 2.738  [notice] Preparing Drupal ("public") + Chado ("testchado").
#13 2.779  [notice] Creating Tripal Custom Tables...
#13 2.825  [notice] Creating Tripal Materialized Views...
#13 2.890  [notice] Loading Terms and Ontologies...
#13 4.677  [notice] Importing The Sequence Ontology
#13 4.718  [notice] Downloading URL "http://purl.obolibrary.org/obo/so.obo", saving to "/tmp/obo_MDfKpn"
#13 5.006  [notice] Importing into schema "testchado"
#13 5.006  [notice] Step 1: Preloading File "/tmp/obo_MDfKpn"...
```

Note: We do not expect a difference in the automated tests since the PHPUnit.xml is not changed in this PR to respect the Tripal core deprecations.