### PR TITLE
Fixed mismatch between terms used for Research Study

### DIFF
--- a/config/install/tripal.tripalfield_collection.trpcultivate_experiments.yml
+++ b/config/install/tripal.tripalfield_collection.trpcultivate_experiments.yml
@@ -1041,7 +1041,7 @@ fields:
         settings:
             termIdSpace: rdfs
             termAccession: type
-            fixed_value: "SIO:001066"
+            fixed_value: "SEPIO:0000125"
         display:
           view:
             default:


### PR DESCRIPTION
**Issue #112**

## Motivation
<!-- This can usually be copied from the issue.
     Please do not just say, go see issue but instead
    copy the relevant details here. -->
Publishing fails for the "Research Study" as it claims there is nothing to publish even when there is.

## What does this PR do?
<!-- Please describe each things this PR does.
     For example, a PR may 1) solve a specific bug,
     2) create an automated test to ensure it doesn't return. -->

Before this PR, when we try to publish "Research Study" content when content exists, it gives an error saying that `There are no records to publish for this content type`. This PR fixes that.

## Testing

<!-- ### Automated Testing
Please describe each automated test this PR creates
     and provide a list of the assertions it makes using casual language.
     Do not just say things like "asserts the array is not empty"
     but rather say "Ensures that the return value of method X
     with these parameters is not an empty array". -->



### Manual Testing
<!-- Describe in detail how someone should manually test this functionality.
     Make sure to include whether they need to build a docker from scratch,
     create any records, configure anything, etc. -->

1. Start a fresh docker image/container on this branch. 
2. Create a research study through the UI.
3. Unpublish it.
4. Publish the "Research Study" content type.
5. It should publish the content without any errors.
