### PR TITLE
GBUG.119 - Restrict the selection of organism in entity.

### DIFF
--- a/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
+++ b/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
@@ -336,6 +336,7 @@ class ProjectGenusWidget extends ChadoWidgetBase {
       foreach ($current_values as $delta => $values) {
         if ($values['organism_id'] != '') {
           $elements[$delta]['organism_id']['#attributes'] = [
+            'readonly' => 'readonly',
             'style' => 'pointer-events: none; background-color: #F0F0F0',
           ];
 
@@ -349,6 +350,30 @@ class ProjectGenusWidget extends ChadoWidgetBase {
         unset($elements[$max_field_delta]['organism_id']['#options'][$organism_id]);
       }
     }
+
+
+    // Disable organism select field with organism already set on page load.
+    if (($storage_initial_values = $form_state->getStorage()['initial_values']) != NULL) {
+
+      $used_organism = [];
+      foreach ($storage_initial_values[$genus_field_name] as $delta => $values) {
+        if ($values['organism_id'] > 0) {
+          $elements[$delta]['organism_id']['#attributes'] = [
+            'readonly' => 'readonly',
+            'style' => 'pointer-events: none; background-color: #F0F0F0',
+          ];
+
+          $used_organism[] = $values['organism_id'];
+        }
+      }
+
+      // Update the the available organism for selection in added select
+      // organism field.
+      foreach($used_organism as $organism_id) {
+        unset($elements[$max_field_delta]['organism_id']['#options'][$organism_id]);
+      }
+    }
+
 
     return $elements;
   }

--- a/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
+++ b/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
@@ -330,8 +330,8 @@ class ProjectGenusWidget extends ChadoWidgetBase {
 
     $set_organism = [];
 
-    // Listen for events - which button is clicked and if storage has saved
-    // organism values.
+    // Listen for events - which button is clicked and if storage has organism
+    // values stored.
     $trigger_el_value = $form_state->getTriggeringElement()['#value'] ?? 0;
 
     if ($trigger_el_value == (string) $elements['add_more']['#value'] || $trigger_el_value == 'Remove') {

--- a/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
+++ b/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
@@ -312,13 +312,13 @@ class ProjectGenusWidget extends ChadoWidgetBase {
     $elements = parent::formMultipleElements($items, $form, $form_state);
 
     $genus_field_name = $items->getName();
-    $max_field_delta = $elements['#max_delta'];
-    $id_key = 'organism_id';
+    $last_delta = $elements['#max_delta'];
+    $organism_id_key = 'organism_id';
 
-    // Ensure only one organism at a time by appying field states property to
+    // Ensure only one organism at a time by appying field #states property to
     // add more button to disable itself if an organism select field has not
     // been set a value.
-    $item_el = $genus_field_name . '[' . $max_field_delta . '][organism_id]';
+    $item_el = $genus_field_name . '[' . $last_delta . '][organism_id]';
     $elements['add_more']['#states'] = [
       'disabled' => [
         ':input[name="' . $item_el . '"]' => ['value' => '']
@@ -328,47 +328,36 @@ class ProjectGenusWidget extends ChadoWidgetBase {
       ]
     ];
 
-    $set_organism = [];
-
-    // Listen for events - which button is clicked and if storage has organism
-    // values stored.
-    $trigger_el_value = $form_state->getTriggeringElement()['#value'] ?? 0;
-
-    if ($trigger_el_value == (string) $elements['add_more']['#value'] || $trigger_el_value == 'Remove') {
-      // Add another item or remove button trigger.
-      $current_values = $form_state->getUserInput()[$genus_field_name] ?? [];
-
-      foreach ($current_values as $delta => $values) {
-        if ($values[$id_key] != '') {
-          $set_organism[$delta] = $values[$id_key];
-        }
+    foreach ($items as $delta => $_) {
+      if ($delta == $last_delta) {
+        break;
       }
-    }
-    elseif (($storage_initial_values = $form_state->getStorage()['initial_values']) != NULL) {
-      // On page load.
-      foreach ($storage_initial_values[$genus_field_name] as $delta => $values) {
-        if ($values[$id_key] != '' && $values[$id_key] != 0) {
-          $set_organism[] = $values[$id_key];
-        }
-      }
-    }
 
-    if ($set_organism) {
-      // Modify behaviour of elements.
+      $organism_default_val = $elements[$delta][$organism_id_key]['#default_value'] ?? 0;
+      $organism_input_val = $form_state->getUserInput()[$genus_field_name][$delta][$organism_id_key] ?? 0;
+      $organism_value = $organism_input_val ?: $organism_default_val;
 
-      foreach ($set_organism as $delta => $organism_id) {
-        // Before adding another select field, disable already set organism - no
-        // more alteration at this point.
-        $elements[$delta][$id_key]['#attributes'] = [
+      if (isset($elements[$delta]) && !empty($organism_value)) {
+        // Visually disable the field without using #disabled fiel $form;d render array
+        // property. Keeping element enabled ensures its value is included in
+        // each AJAX request (add/remove), whereas a disabled field would not be
+        // submitted by the browser.
+        $elements[$delta][$organism_id_key]['#attributes'] = [
           'readonly' => 'readonly',
-          'style' => 'pointer-events: none; background-color: #F0F0F0',
+          'style' => 'pointer-events: none; opacity: 0.5;',
         ];
 
-        // Update the available organism for selection in the remaining select
-        // organism field by removing in used organism - no duplicate allowed.
-        unset($elements[$max_field_delta][$id_key]['#options'][$organism_id]);
-      }
+        // Repopulate the new blank organism select field so that the previously
+        // set organism will no longer be suggested.
+        unset($elements[$last_delta][$organism_id_key]['#options'][$organism_value]);
+      } $form;
     }
+
+    // At any time, the form contains one blank organism select field by design.
+    // When there are two elements, removing the blank will override the current
+    // or saved value into a blank field. Disabling remove button prevents this.
+    $elements[$last_delta]['_actions']['delete']['#disabled'] =
+      (empty($elements[$last_delta][$organism_id_key]['#options']) || $last_delta == 1) ? TRUE : FALSE;
 
     return $elements;
   }

--- a/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
+++ b/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
@@ -24,13 +24,6 @@ use Drupal\tripal_chado\Controller\ChadoOrganismFormElementController;
 class ProjectGenusWidget extends ChadoWidgetBase {
 
   /**
-   * Flag if all genus has been used up.
-   *
-   * @var bool
-   */
-  protected bool $all_genus_used = FALSE;
-
-  /**
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
@@ -143,24 +136,6 @@ class ProjectGenusWidget extends ChadoWidgetBase {
     // Get the organism select element or auto-complete element.
     $select_element = ChadoOrganismFormElementController::getFormElement($elements, $organism_id, $options);
     $storage = $form_state->getStorage();
-
-    // Do not suggest already selected genus and disable add more item.
-    if ($item_vals === [] && $storage) {
-      $selected_organism = array_column(
-        $form_state->getStorage()['initial_values'][$field_name],
-        'organism_id'
-      );
-
-      $genus_used_ctr = 0;
-      foreach ($select_element['#options'] as $organism_id => $_) {
-        if (is_array($selected_organism) && in_array($organism_id, $selected_organism)) {
-          unset($select_element['#options'][$organism_id]);
-          $genus_used_ctr++;
-        }
-      }
-
-      $this->all_genus_used = ($genus_used_ctr == count($selected_organism)) ? TRUE : FALSE;
-    }
 
     $elements['organism_id'] = $element + $select_element;
 
@@ -336,12 +311,41 @@ class ProjectGenusWidget extends ChadoWidgetBase {
 
     $elements = parent::formMultipleElements($items, $form, $form_state);
 
-    if ($this->all_genus_used) {
-      $elements['add_more']['#disabled'] = TRUE;
+    $max_field_delta = $elements['#max_delta'];
 
-      $elements['#max_delta'] -= 1;
-      unset($elements[$elements['#max_delta'] + 1]);
+    if (($storage_initial_values = $form_state->getStorage()['initial_values']) != NULL) {
+      $genus_field_name = $items->getName();
+
+      // Filter all organism id that are > than 0 (not the value of select
+      // placeholder text).
+      $genus_field_values = array_filter(
+        array_column($storage_initial_values[$genus_field_name], 'organism_id'),
+        function ($organism_id) { return (int) $organism_id > 0; }
+      );
     }
+
+    // Disable already filled in organism field.
+    for ($i = 0; $i <= $max_field_delta; $i++) {
+
+      if ($i != $max_field_delta) {
+        $elements[$i]['organism_id']['#disabled'] = TRUE;
+      }
+    }
+
+    // Remove from select box already used organism - the last select box.
+    foreach ($genus_field_values as $organism_id) {
+      unset($elements[$max_field_delta]['organism_id']['#options'][$organism_id]);
+    }
+
+    // If all organism have been used up, do not provide any more select field
+    // and disable the add another item.
+    if (count($elements[$max_field_delta]['organism_id']['#options']) == 0) {
+      unset($elements[$max_field_delta]);
+      $elements['#max_delta'] -= 1;
+
+      $elements['add_more']['#disabled'] = TRUE;
+    }
+
     return $elements;
   }
 

--- a/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
+++ b/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
@@ -24,6 +24,13 @@ use Drupal\tripal_chado\Controller\ChadoOrganismFormElementController;
 class ProjectGenusWidget extends ChadoWidgetBase {
 
   /**
+   * Flag if all genus has been used up.
+   *
+   * @var bool
+   */
+  protected bool $all_genus_used = FALSE;
+
+  /**
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
@@ -135,6 +142,26 @@ class ProjectGenusWidget extends ChadoWidgetBase {
 
     // Get the organism select element or auto-complete element.
     $select_element = ChadoOrganismFormElementController::getFormElement($elements, $organism_id, $options);
+    $storage = $form_state->getStorage();
+
+    // Do not suggest already selected genus and disable add more item.
+    if ($item_vals === [] && $storage) {
+      $selected_organism = array_column(
+        $form_state->getStorage()['initial_values'][$field_name],
+        'organism_id'
+      );
+
+      $genus_used_ctr = 0;
+      foreach ($select_element['#options'] as $organism_id => $_) {
+        if (is_array($selected_organism) && in_array($organism_id, $selected_organism)) {
+          unset($select_element['#options'][$organism_id]);
+          $genus_used_ctr++;
+        }
+      }
+
+      $this->all_genus_used = ($genus_used_ctr == count($selected_organism)) ? TRUE : FALSE;
+    }
+
     $elements['organism_id'] = $element + $select_element;
 
     // Save some initial values to allow later handling of the "Remove" button.
@@ -142,7 +169,6 @@ class ProjectGenusWidget extends ChadoWidgetBase {
     // we have two properties in a single item.
     // We want the initial values, so never update them once saved.
     $messenger = \Drupal::messenger();
-    $storage = $form_state->getStorage();
     if (!($storage['initial_values'][$field_name][$delta] ?? FALSE)) {
       if (($organism_id == 0) and ($sciname_prop_id != 0 or ($genus_prop_id != 0))) {
         // Add an error message.
@@ -154,6 +180,7 @@ class ProjectGenusWidget extends ChadoWidgetBase {
           'sciname_linker_id' => $sciname_prop_id,
           'organism_id' => $organism_id,
         ];
+
         $form_state->setStorage($storage);
       }
     }
@@ -300,6 +327,22 @@ class ProjectGenusWidget extends ChadoWidgetBase {
    */
   public function settingsSummary() {
     return $this->selectSettingsSummary() + parent::settingsSummary();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function formMultipleElements(FieldItemListInterface $items, array &$form, FormStateInterface $form_state) {
+
+    $elements = parent::formMultipleElements($items, $form, $form_state);
+
+    if ($this->all_genus_used) {
+      $elements['add_more']['#disabled'] = TRUE;
+
+      $elements['#max_delta'] -= 1;
+      unset($elements[$elements['#max_delta'] + 1]);
+    }
+    return $elements;
   }
 
 }

--- a/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
+++ b/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
@@ -322,7 +322,7 @@ class ProjectGenusWidget extends ChadoWidgetBase {
     // submitted during AJAX add/remove operations.
     $readonly_attributes = [
       'readonly' => 'readonly',
-      'style' => 'pointer-events: none; opacity: 0.6;',
+      'style' => 'pointer-events: none; opacity: 0.4;',
     ];
 
     // Listen for values set to the blank organism select field.

--- a/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
+++ b/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
@@ -310,40 +310,44 @@ class ProjectGenusWidget extends ChadoWidgetBase {
   protected function formMultipleElements(FieldItemListInterface $items, array &$form, FormStateInterface $form_state) {
 
     $elements = parent::formMultipleElements($items, $form, $form_state);
-
+    $genus_field_name = $items->getName();
     $max_field_delta = $elements['#max_delta'];
 
-    if (($storage_initial_values = $form_state->getStorage()['initial_values']) != NULL) {
-      $genus_field_name = $items->getName();
+    // Ensure only one organism at a time by appying field states property to
+    // add more button to disable itself if an organism select field has not
+    // been set a value.
+    $item_el = $genus_field_name . '[' . $max_field_delta . '][organism_id]';
+    $elements['add_more']['#states'] = [
+      'disabled' => [
+        ':input[name="' . $item_el . '"]' => ['value' => '']
+      ],
+      'enabled' => [
+        ':input[name="' . $item_el . '"]' => ['filled' => TRUE]
+      ]
+    ];
 
-      // Filter all organism id that are > than 0 (not the value of select
-      // placeholder text).
-      $genus_field_values = array_filter(
-        array_column($storage_initial_values[$genus_field_name], 'organism_id'),
-        function ($organism_id) { return (int) $organism_id > 0; }
-      );
-    }
+    // Before adding another select field, disable already set organism - no
+    // more alteration at this point.
+    $trigger_el = $form_state->getTriggeringElement() ?? 0;
+    if ($trigger_el && $trigger_el['#name'] == 'exp_organism_add_more') {
+      $current_values = $form_state->getUserInput()[$genus_field_name] ?? [];
 
-    // Disable already filled in organism field.
-    for ($i = 0; $i <= $max_field_delta; $i++) {
+      $used_organism = [];
+      foreach ($current_values as $delta => $values) {
+        if ($values['organism_id'] != '') {
+          $elements[$delta]['organism_id']['#attributes'] = [
+            'style' => 'pointer-events: none; background-color: #F0F0F0',
+          ];
 
-      if ($i != $max_field_delta) {
-        $elements[$i]['organism_id']['#disabled'] = TRUE;
+          $used_organism[] = $values['organism_id'];
+        }
       }
-    }
 
-    // Remove from select box already used organism - the last select box.
-    foreach ($genus_field_values as $organism_id) {
-      unset($elements[$max_field_delta]['organism_id']['#options'][$organism_id]);
-    }
-
-    // If all organism have been used up, do not provide any more select field
-    // and disable the add another item.
-    if (count($elements[$max_field_delta]['organism_id']['#options']) == 0) {
-      unset($elements[$max_field_delta]);
-      $elements['#max_delta'] -= 1;
-
-      $elements['add_more']['#disabled'] = TRUE;
+      // Update the available organism for selection in the newly added
+      // select organism field.
+      foreach($used_organism as $organism_id) {
+        unset($elements[$max_field_delta]['organism_id']['#options'][$organism_id]);
+      }
     }
 
     return $elements;

--- a/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
+++ b/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
@@ -310,8 +310,10 @@ class ProjectGenusWidget extends ChadoWidgetBase {
   protected function formMultipleElements(FieldItemListInterface $items, array &$form, FormStateInterface $form_state) {
 
     $elements = parent::formMultipleElements($items, $form, $form_state);
+
     $genus_field_name = $items->getName();
     $max_field_delta = $elements['#max_delta'];
+    $id_key = 'organism_id';
 
     // Ensure only one organism at a time by appying field states property to
     // add more button to disable itself if an organism select field has not
@@ -326,54 +328,47 @@ class ProjectGenusWidget extends ChadoWidgetBase {
       ]
     ];
 
-    // Before adding another select field, disable already set organism - no
-    // more alteration at this point.
-    $trigger_el = $form_state->getTriggeringElement() ?? 0;
-    if ($trigger_el && $trigger_el['#name'] == 'exp_organism_add_more') {
+    $set_organism = [];
+
+    // Listen for events - which button is clicked and if storage has saved
+    // organism values.
+    $trigger_el_value = $form_state->getTriggeringElement()['#value'] ?? 0;
+
+    if ($trigger_el_value == (string) $elements['add_more']['#value'] || $trigger_el_value == 'Remove') {
+      // Add another item or remove button trigger.
       $current_values = $form_state->getUserInput()[$genus_field_name] ?? [];
 
-      $used_organism = [];
       foreach ($current_values as $delta => $values) {
-        if ($values['organism_id'] != '') {
-          $elements[$delta]['organism_id']['#attributes'] = [
-            'readonly' => 'readonly',
-            'style' => 'pointer-events: none; background-color: #F0F0F0',
-          ];
-
-          $used_organism[] = $values['organism_id'];
+        if ($values[$id_key] != '') {
+          $set_organism[$delta] = $values[$id_key];
         }
       }
-
-      // Update the available organism for selection in the newly added
-      // select organism field.
-      foreach($used_organism as $organism_id) {
-        unset($elements[$max_field_delta]['organism_id']['#options'][$organism_id]);
-      }
     }
-
-
-    // Disable organism select field with organism already set on page load.
-    if (($storage_initial_values = $form_state->getStorage()['initial_values']) != NULL) {
-
-      $used_organism = [];
+    elseif (($storage_initial_values = $form_state->getStorage()['initial_values']) != NULL) {
+      // On page load.
       foreach ($storage_initial_values[$genus_field_name] as $delta => $values) {
-        if ($values['organism_id'] > 0) {
-          $elements[$delta]['organism_id']['#attributes'] = [
-            'readonly' => 'readonly',
-            'style' => 'pointer-events: none; background-color: #F0F0F0',
-          ];
-
-          $used_organism[] = $values['organism_id'];
+        if ($values[$id_key] != '' && $values[$id_key] != 0) {
+          $set_organism[] = $values[$id_key];
         }
-      }
-
-      // Update the the available organism for selection in added select
-      // organism field.
-      foreach($used_organism as $organism_id) {
-        unset($elements[$max_field_delta]['organism_id']['#options'][$organism_id]);
       }
     }
 
+    if ($set_organism) {
+      // Modify behaviour of elements.
+
+      foreach ($set_organism as $delta => $organism_id) {
+        // Before adding another select field, disable already set organism - no
+        // more alteration at this point.
+        $elements[$delta][$id_key]['#attributes'] = [
+          'readonly' => 'readonly',
+          'style' => 'pointer-events: none; background-color: #F0F0F0',
+        ];
+
+        // Update the available organism for selection in the remaining select
+        // organism field by removing in used organism - no duplicate allowed.
+        unset($elements[$max_field_delta][$id_key]['#options'][$organism_id]);
+      }
+    }
 
     return $elements;
   }

--- a/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
+++ b/src/Plugin/Field/FieldWidget/ProjectGenusWidget.php
@@ -311,53 +311,64 @@ class ProjectGenusWidget extends ChadoWidgetBase {
 
     $elements = parent::formMultipleElements($items, $form, $form_state);
 
-    $genus_field_name = $items->getName();
-    $last_delta = $elements['#max_delta'];
-    $organism_id_key = 'organism_id';
+    $organism_field_name = $items->getName();
+    $organism_field_key = 'organism_id';
+    // The pattern used to compose each organism select field name attribute.
+    $organism_field = "{$organism_field_name}[%d][{$organism_field_key}]";
 
-    // Ensure only one organism at a time by appying field #states property to
-    // add more button to disable itself if an organism select field has not
-    // been set a value.
-    $item_el = $genus_field_name . '[' . $last_delta . '][organism_id]';
-    $elements['add_more']['#states'] = [
-      'disabled' => [
-        ':input[name="' . $item_el . '"]' => ['value' => '']
-      ],
-      'enabled' => [
-        ':input[name="' . $item_el . '"]' => ['filled' => TRUE]
-      ]
+    $last_delta = $elements['#max_delta'];
+
+    // Visually disable a field while keeping it enabled so its value is still
+    // submitted during AJAX add/remove operations.
+    $readonly_attributes = [
+      'readonly' => 'readonly',
+      'style' => 'pointer-events: none; opacity: 0.6;',
     ];
 
+    // Listen for values set to the blank organism select field.
+    $last_field_selector = ':input[name="' . sprintf($organism_field, $last_delta) . '"]';
+    $toggle_states = [
+      'disabled' => [$last_field_selector => ['value' => '']],
+      'enabled' => [$last_field_selector => ['filled' => TRUE]],
+    ];
+
+    // One field at a time. Prevent adding another row until organism is set.
+    $elements['add_more']['#states'] = $toggle_states;
+
+    // Other sources of field value other than the #default_value attribute.
+    $user_input = $form_state->getUserInput();
+    $storgage = $form_state->getStorage();
+
+    // Disable set organism fields.
     foreach ($items as $delta => $_) {
+      $default_value = $elements[$delta][$organism_field_key]['#default_value'] ?? NULL;
+      $input_value = $user_input[$organism_field_name][$delta][$organism_field_key] ?? NULL;
+      $organism_id = $input_value ?: $default_value;
+
       if ($delta == $last_delta) {
+        $storage_value = $storgage['initial_values'][$organism_field_name][$delta][$organism_field_key] ?? NULL;
+        if ($organism_id ??= $storage_value) {
+          // Lock organism that has become the blank field.
+          $elements[$delta][$organism_field_key]['#attributes'] = $readonly_attributes;
+        }
+
         break;
       }
 
-      $organism_default_val = $elements[$delta][$organism_id_key]['#default_value'] ?? 0;
-      $organism_input_val = $form_state->getUserInput()[$genus_field_name][$delta][$organism_id_key] ?? 0;
-      $organism_value = $organism_input_val ?: $organism_default_val;
+      if (!isset($elements[$delta]) && empty($organism_id)) {
+        continue;
+      }
 
-      if (isset($elements[$delta]) && !empty($organism_value)) {
-        // Visually disable the field without using #disabled fiel $form;d render array
-        // property. Keeping element enabled ensures its value is included in
-        // each AJAX request (add/remove), whereas a disabled field would not be
-        // submitted by the browser.
-        $elements[$delta][$organism_id_key]['#attributes'] = [
-          'readonly' => 'readonly',
-          'style' => 'pointer-events: none; opacity: 0.5;',
-        ];
+      // Lock previously selected organism.
+      $elements[$delta][$organism_field_key]['#attributes'] = $readonly_attributes;
 
-        // Repopulate the new blank organism select field so that the previously
-        // set organism will no longer be suggested.
-        unset($elements[$last_delta][$organism_id_key]['#options'][$organism_value]);
-      } $form;
+      // Repopulate the new blank organism select field so that the previously
+      // set organism will no longer be suggested.
+      unset($elements[$last_delta][$organism_field_key]['#options'][$organism_id]);
     }
 
-    // At any time, the form contains one blank organism select field by design.
-    // When there are two elements, removing the blank will override the current
-    // or saved value into a blank field. Disabling remove button prevents this.
-    $elements[$last_delta]['_actions']['delete']['#disabled'] =
-      (empty($elements[$last_delta][$organism_id_key]['#options']) || $last_delta == 1) ? TRUE : FALSE;
+    // Prevent deletion of blank select field.
+    $elements[$last_delta]['_actions']['delete']['#states'] = $toggle_states;
 
     return $elements;
   }

--- a/tests/src/Kernel/Plugin/ChadoField/FieldWidget/ProjectGenusWidgetFormTest.php
+++ b/tests/src/Kernel/Plugin/ChadoField/FieldWidget/ProjectGenusWidgetFormTest.php
@@ -262,7 +262,7 @@ class ProjectGenusWidgetFormTest extends ChadoTestKernelBase {
 
     // Create test research experiment entity and set Lens as an entry to the
     // organism field.
-    $exp_entity =TripalEntity::create([
+    $exp_entity = TripalEntity::create([
       'type' => 'research_experiment',
       'exp_name' => [
         'record_id' => $project_id,

--- a/tests/src/Kernel/Plugin/ChadoField/FieldWidget/ProjectGenusWidgetFormTest.php
+++ b/tests/src/Kernel/Plugin/ChadoField/FieldWidget/ProjectGenusWidgetFormTest.php
@@ -312,7 +312,7 @@ class ProjectGenusWidgetFormTest extends ChadoTestKernelBase {
         $this->assertStringContainsString(
           $organism,
           $select_field->asXML(),
-          'The organism select field does not contain the expected orgnism option in select delta ' . $delta,
+          'The organism select field does not contain the expected organism option in select delta ' . $delta,
         );
       }
 

--- a/tests/src/Kernel/Plugin/ChadoField/FieldWidget/ProjectGenusWidgetFormTest.php
+++ b/tests/src/Kernel/Plugin/ChadoField/FieldWidget/ProjectGenusWidgetFormTest.php
@@ -342,6 +342,16 @@ class ProjectGenusWidgetFormTest extends ChadoTestKernelBase {
       $add_more_button->asXML(),
       'The states definition applied to add more button is expected to render it disabled by default.',
     );
+
+    // Test that with 2 items, the remove button of the blank select field is
+    // disabled.
+    $remove_more_button = $this->cssSelect('input[name="exp_organism_1_remove_button"]')[0];
+
+    $this->assertStringContainsString(
+      'disabled',
+      $remove_more_button->asXML(),
+      'The last organism select field is expected to be disabled if there are 2 select elements.',
+    );
   }
 
 }

--- a/tests/src/Kernel/Plugin/ChadoField/FieldWidget/ProjectGenusWidgetFormTest.php
+++ b/tests/src/Kernel/Plugin/ChadoField/FieldWidget/ProjectGenusWidgetFormTest.php
@@ -26,7 +26,6 @@ use Symfony\Component\HttpFoundation\Request;
 class ProjectGenusWidgetFormTest extends ChadoTestKernelBase {
 
   use ChadoFieldTestTrait;
-  use UserCreationTrait;
 
   /**
    * The theme to use when rendering content in the test environment.

--- a/tests/src/Kernel/Plugin/ChadoField/FieldWidget/ProjectGenusWidgetFormTest.php
+++ b/tests/src/Kernel/Plugin/ChadoField/FieldWidget/ProjectGenusWidgetFormTest.php
@@ -295,7 +295,7 @@ class ProjectGenusWidgetFormTest extends ChadoTestKernelBase {
     $this->assertEquals(
       count($test_organism),
       count($organism_row),
-      'The edit page does not contain expected number of seleect organism fields.',
+      'The edit page does not contain expected number of select organism fields.',
     );
 
     $organism_select = $this->cssSelect('select', $organism_row);

--- a/tests/src/Kernel/Plugin/ChadoField/FieldWidget/ProjectGenusWidgetFormTest.php
+++ b/tests/src/Kernel/Plugin/ChadoField/FieldWidget/ProjectGenusWidgetFormTest.php
@@ -4,9 +4,12 @@ namespace Drupal\Tests\trpcultivate\Kernel\Plugin\ChadoField\Widget;
 
 use Drupal\Tests\tripal_chado\Kernel\ChadoTestKernelBase;
 use Drupal\Tests\tripal_chado\Traits\ChadoFieldTestTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\tripal\Entity\TripalEntity;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Tests the ChadoPropertyTypeDefault Field Type.
@@ -23,6 +26,7 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 class ProjectGenusWidgetFormTest extends ChadoTestKernelBase {
 
   use ChadoFieldTestTrait;
+  use UserCreationTrait;
 
   /**
    * The theme to use when rendering content in the test environment.
@@ -40,6 +44,7 @@ class ProjectGenusWidgetFormTest extends ChadoTestKernelBase {
    * @var array
    */
   protected static $modules = [
+    'node',
     'system',
     'user',
     'path',
@@ -231,6 +236,112 @@ class ProjectGenusWidgetFormTest extends ChadoTestKernelBase {
       $entity = $form_object->getEntity();
       $this->assertFieldValuesMatch($current_scenario['edit']['expected_field_values'], $entity, "Field values didn't match our expectations after saving the edit form");
     }
+  }
+
+  /**
+   * Test formMultipleElements() method.
+   */
+  public function testFormMultipleElements() {
+
+    $test_organism = ['Lens culinaris', 'Triticum durum'];
+
+    $organism_ids = [];
+    foreach ($test_organism as $organism) {
+      [$genus, $species] = explode(' ', $organism);
+
+      $organism_ids[$organism] = $this->chado_connection
+        ->insert('1:organism')
+        ->fields(['genus' => $genus, 'species' => $species, 'type_id' => 1])
+        ->execute();
+    }
+
+    $exp_name = 'Test Project';
+    $project_id = $this->chado_connection->insert('1:project')
+      ->fields(['name' => $exp_name])
+      ->execute();
+
+    // Create test research experiment entity and set Lens as an entry to the
+    // organism field.
+    $exp_entity =TripalEntity::create([
+      'type' => 'research_experiment',
+      'exp_name' => [
+        'record_id' => $project_id,
+        'value' => $exp_name,
+      ],
+      'exp_organism' => [
+        'record_id' => $project_id,
+        'organism_id' => reset($organism_ids),
+        'genus_value' => 'Lens',
+        'sciname_value' => reset($test_organism),
+      ],
+    ]);
+
+    $exp_entity->save();
+
+    $exp_entity_edit = '/bio_data/' . $exp_entity->id() . '/edit';
+    $edit_page_content = $this->container->get('http_kernel')
+      ->handle(Request::create($exp_entity_edit))
+      ->getContent();
+
+    $this->setRawContent($edit_page_content);
+
+    // Table used to organize each select organism field and control buttons.
+    $table = $this->cssSelect('table');
+
+    $organism_row = $this->cssSelect('tbody tr', $table);
+
+    // Test that for each organism entry, the set organism (Lens) is no longer
+    // suggested in subsequent select organism field.
+    $this->assertEquals(
+      count($test_organism),
+      count($organism_row),
+      'The edit page does not contain expected number of seleect organism fields.',
+    );
+
+    $organism_select = $this->cssSelect('select', $organism_row);
+    foreach ($organism_select as $delta => $select_field) {
+      // + 1 to account for the - Select - option.
+      $this->assertCount(
+        count($test_organism) + 1,
+        $select_field,
+        'The organism select field does not contain the expected number of options in select delta ' . $delta,
+      );
+
+      // The current select field contains the correct organism as options.
+      foreach ($test_organism as $organism) {
+        $this->assertStringContainsString(
+          $organism,
+          $select_field->asXML(),
+          'The organism select field does not contain the expected orgnism option in select delta ' . $delta,
+        );
+      }
+
+      // In the next select item, options should no longer contain Lens.
+      array_shift($test_organism);
+    }
+
+    // Test that the set genus in first select field (item 0) is disabled.
+    $this->assertStringContainsString(
+      'readonly',
+      $organism_select[0]->asXML(),
+      'The select field with set genus is expected to appear disabled.',
+    );
+
+    // Test that field #states definition applied to 'add more select field'
+    // button renders it disabled.
+    $add_more_button = $this->cssSelect('input[name="exp_organism_add_more"]')[0];
+
+    $this->assertStringContainsString(
+      'states',
+      $add_more_button->asXML(),
+      'The add more button is expected to contain Drupal states property.',
+    );
+
+    $this->assertStringContainsString(
+      'disabled',
+      $add_more_button->asXML(),
+      'The states definition applied to add more button is expected to render it disabled by default.',
+    );
   }
 
 }


### PR DESCRIPTION
**Issue #119 **

## Motivation
<!-- This can usually be copied from the issue.
     Please do not just say, go see issue but instead
    copy the relevant details here. -->

The entity with organism genus field, does not implement any restrictions to the selection of organism. This PR applies basic field restriction to prevent user from:

- [x] Select and add the same organism.
- [x] Interact with more than one select field at a time.
- [x] Alter already set organism. 

## What does this PR do?
<!-- Please describe each things this PR does.
     For example, a PR may 1) solve a specific bug,
     2) create an automated test to ensure it doesn't return. -->

- [x] Use Drupal field #states property to enable and disable elements.
- [x] Implement formMultipleElements() (see Drupal core for examples) to modify select options.
- [x] Setup automated test.

## Testing

### Automated Testing
<!-- Please describe each automated test this PR creates
     and provide a list of the assertions it makes using casual language.
     Do not just say things like "asserts the array is not empty"
     but rather say "Ensures that the return value of method X
     with these parameters is not an empty array". -->

### Manual Testing
<!-- Describe in detail how someone should manually test this functionality.
     Make sure to include whether they need to build a docker from scratch,
     create any records, configure anything, etc. -->

1. Start a fresh docker image/container on this branch. **You can use the devcontainer approach OR the following commands:**
  ```
  cd ~/Dockers
  git clone https://github.com/TripalCultivate/TripalCultivate trpcultBase-PRNUM
  git checkout BRANCHNAME
  cd trpcultBase-PRNUM
  docker build --tag=trpcultivate-base:reviewPRNUM ./
  docker run --publish=80:80 -tid --name=basePRNUM --volume=`pwd`:/var/www/drupal/web/modules/contrib/TripalCultivate trpcultivate-base:reviewPRNUM
  ```

3. Create organism - as many as desired.
4. Create a research experiment content and save.
5. Edit the entity and under Design vertical tab
<img width="639" height="468" alt="image" src="https://github.com/user-attachments/assets/e74b0a93-786a-48d1-9aa3-b9e98d04bc1d" />

Test the following:

1. At any given time, you are allowed to add only 1 blank select organism field.
2. Once an organism has been set, subsequent select field will omit that organism from the selections.
3. Selected organism will be disabled and saved organism will be disabled in the next page edit.
4. Removing an organism will re-populate a blank select field to make that organism available once again.
