### PR TITLE
G0.131 - Allow more traits into header description of importer without expanding the form height

### DIFF
--- a/css/style-describe-header-window.css
+++ b/css/style-describe-header-window.css
@@ -9,17 +9,6 @@
   margin: 0 0 10px 0;
 }
 
-/* Traits window */
-#tcp-header-notes > div {
-  position: relative;
-  border: 1px solid #DADADA;
-  border-radius: 8px;
-  max-height: 350px;
-  margin-bottom: 10px;
-  overflow-y: auto;
-  padding: 20px 20px 0 20px;
-}
-
 #tcp-header-notes li {
   border-bottom: 1px solid #DADADA;
   margin: 0;
@@ -40,22 +29,58 @@
   margin: 0;
 }
 
-.tcp-details-partial-reveal {
+/* Expandable traits window */
+:root {
+  --window-height: 525px;
+}
+
+#tcp-expandable-window {
+  border: 1px solid #DADADA;
+  border-radius: 8px;
+  margin-bottom: 10px;
+  padding: 20px 20px 0 20px;
+  position: relative;
+}
+
+.tcp-window-min {
+  max-height: var(--window-height);
+  overflow-y: auto;
+}
+
+.tcp-window-max {
+  max-height: none;
+  overflow-y: visible;
+}
+
+#tcp-expandable-window > div {
   background: linear-gradient(to bottom, transparent, var(--gin-bg-layer));
   bottom: 0;
-  height: 40px;
+  height: 60px;
+  padding: 0;
   position: sticky;
-  padding: 0;
   margin: 0;
 }
 
-.fa-circle-check, #tcp-header-notes > span {
-  margin: 20px 0 0 0;
+/* Check before uploading */
+#tripal-importer-describe-file-upload > i,
+#tripal-importer-describe-file-upload > span {
   font-size: 1.5em;
+  letter-spacing: -1px;
+  margin: 20px 0 0 0;
 }
 
-#tcp-header-notes p:last-child {
+#tripal-importer-describe-file-upload p:last-child {
+  line-height: 1.2;
   margin: 0;
   padding: 0;
-  line-height: 1.2;
+}
+
+/* Window title */
+#tripal-importer-describe-file-upload > p {
+  position: relative;
+}
+
+#tripal-importer-describe-file-upload > p > span {
+  position: absolute;
+  right: 0;
 }

--- a/css/style-describe-header-window.css
+++ b/css/style-describe-header-window.css
@@ -5,22 +5,57 @@
 
 /* Importer notes */
 #tcp-header-notes {
-  font-weight: 300;
   list-style-position: inside;
   margin: 0 0 10px 0;
 }
 
 /* Traits window */
-#tcp-header-notes div {
+#tcp-header-notes > div {
+  position: relative;
   border: 1px solid #DADADA;
-  border-bottom-width: 3px;
   border-radius: 8px;
   max-height: 350px;
   margin-bottom: 10px;
   overflow-y: auto;
-  padding: 20px;
+  padding: 20px 20px 0 20px;
 }
 
-#tcp-header-notes p {
-  margin-top: 0;
+#tcp-header-notes li {
+  border-bottom: 1px solid #DADADA;
+  margin: 0;
+  padding: 10px 0;
+}
+
+#tcp-header-notes li:first-child {
+  padding-top: 0;
+}
+
+#tcp-header-notes li:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+#tcp-header-notes li p {
+  padding: 0;
+  margin: 0;
+}
+
+.tcp-details-partial-reveal {
+  background: linear-gradient(to bottom, transparent, var(--gin-bg-layer));
+  bottom: 0;
+  height: 40px;
+  position: sticky;
+  padding: 0;
+  margin: 0;
+}
+
+.fa-circle-check, #tcp-header-notes > span {
+  margin: 20px 0 0 0;
+  font-size: 1.5em;
+}
+
+#tcp-header-notes p:last-child {
+  margin: 0;
+  padding: 0;
+  line-height: 1.2;
 }

--- a/css/style-describe-header-window.css
+++ b/css/style-describe-header-window.css
@@ -10,6 +10,17 @@
   margin: 0 0 10px 0;
 }
 
+/* Traits window */
+#tcp-header-notes div {
+  border: 1px solid #DADADA;
+  border-bottom-width: 3px;
+  border-radius: 8px;
+  max-height: 350px;
+  margin-bottom: 10px;
+  overflow-y: auto;
+  padding: 20px;
+}
+
 #tcp-header-notes p {
   margin-top: 0;
 }

--- a/templates/importer/describe-header-window.html.twig
+++ b/templates/importer/describe-header-window.html.twig
@@ -3,19 +3,31 @@
  * @file
  * Template implementation of importer describe header window.
  *
- * Available variables:
- * - header_notes: array of headers keyed by the header name.
-     Value is description and expected value.
- * - template_file: a file name of a template file.
+ * Available variables as defined by the method describeUploadFileFormat() in
+ * the Tripal importer class.
+ * - data.headers: the list of headers defined by the importer header property.
+ *   Each header metadata can be accessed with the following keys:
+ *   - 'name': the header name
+ *   - 'type': either required or optional.
+ *   - 'description': the header description text.
+ * - data.file_extensions: list of file extensions supported by the importer.
+ * - data.notes: additional notes or reminders related to the upload.
+ * - data.template_file: the file path of the template file provided by the
+ *     template file generator service.
  */
 #}
 
 {{ attach_library('trpcultivate/describe-header-window') }}
 
-<div id="tcp-header-notes">
-  <p>This should be a [{{data.file_extensions}}] file with the following columns:</p>
+<div id="tripal-importer-describe-file-upload">
+  <p>
+    This should be a [{{data.file_extensions}}] file with the following columns:
+    <span class="views-field">
+      <small class="marker">{{data.headers|length}} Columns | <a id="tcp-resize-window" title="Click to expand or collapse the column list below" href="#">Expand</a></small>
+    </span>
+  </p>
 
-  <div>
+  <div id="tcp-expandable-window" class="tcp-window-min">
     <ol id="tcp-header-notes">
       {% for header in data.headers %}
       <li>
@@ -25,13 +37,25 @@
       </li>
       {% endfor %}
     </ol>
-    <div class="tcp-details-partial-reveal"></div>
+    <!-- Partial reveal (bottom blur) element -->
+    <div></div>
   </div>
 
   <i class="fa-regular fa-circle-check"></i>
-  <span>Check Before Uploading</span> | &nbsp; <a id="tcp-template-file" class="button button--small button--secondary" href="{{data.template_file}}" target="_blank">Download a template file</a>
-
-  <p><em>{{data.notes}}</em></p>
+  <span>Check Before Uploading</span> | &nbsp; <a title="Download a template file with the columns above already included" class="button button--small" href="{{data.template_file}}" target="_blank">Download a template file</a>
+  <p><em>{{data.notes|raw}}</em></p>
 </div>
 
 <br />
+
+<script>
+  document.getElementById('tcp-resize-window')
+    .addEventListener('click', function (event) {
+      event.preventDefault();
+
+      // Expand or collapse traits expandable window.
+      const traitWindow = document.getElementById('tcp-expandable-window');
+      this.textContent = traitWindow.classList
+        .toggle('tcp-window-max') ? 'Collapse' : 'Expand';
+    });
+</script>

--- a/templates/importer/describe-header-window.html.twig
+++ b/templates/importer/describe-header-window.html.twig
@@ -19,17 +19,19 @@
     <ol id="tcp-header-notes">
       {% for header in data.headers %}
       <li>
-        <strong>{{header['name']}}</strong>: {{header['description']}} ({{header['type']}})
+        <strong>{{header['name']}}</strong>
+        <span class="views-field"><small class="marker">{{header['type']|capitalize}}</small></span>
+        <p>{{header['description']}}</p>
       </li>
       {% endfor %}
     </ol>
+    <div class="tcp-details-partial-reveal"></div>
   </div>
 
-  <p><em>{{data.notes}}</em></p>
-</div>
+  <i class="fa-regular fa-circle-check"></i>
+  <span>Check Before Uploading</span> | &nbsp; <a id="tcp-template-file" class="button button--small button--secondary" href="{{data.template_file}}" target="_blank">Download a template file</a>
 
-<div id="tcp-template-file">
-  <a href="{{data.template_file}}" target="_blank">Download a template file</a>
+  <p><em>{{data.notes}}</em></p>
 </div>
 
 <br />

--- a/templates/importer/describe-header-window.html.twig
+++ b/templates/importer/describe-header-window.html.twig
@@ -15,13 +15,15 @@
 <div id="tcp-header-notes">
   <p>This should be a [{{data.file_extensions}}] file with the following columns:</p>
 
-  <ol id="tcp-header-notes">
-    {% for header in data.headers %}
-    <li>
-      <strong>{{header['name']}}</strong>: {{header['description']}} ({{header['type']}})
-    </li>
-    {% endfor %}
-  </ol>
+  <div>
+    <ol id="tcp-header-notes">
+      {% for header in data.headers %}
+      <li>
+        <strong>{{header['name']}}</strong>: {{header['description']}} ({{header['type']}})
+      </li>
+      {% endfor %}
+    </ol>
+  </div>
 
   <p><em>{{data.notes}}</em></p>
 </div>


### PR DESCRIPTION
**Issue #130 **

## Motivation
<!-- This can usually be copied from the issue.
     Please do not just say, go see issue but instead
    copy the relevant details here. -->

Allow the trait description section of an importer form to accommodate more traits without expanding the height of the form.

## What does this PR do?
<!-- Please describe each things this PR does.
     For example, a PR may 1) solve a specific bug,
     2) create an automated test to ensure it doesn't return. -->

- [x] Apply CSS to the section so that vertical scrollbar is activated when there are more items to display.

## Testing

### Manual Testing
<!-- Describe in detail how someone should manually test this functionality.
     Make sure to include whether they need to build a docker from scratch,
     create any records, configure anything, etc. -->

1. Start a fresh docker image/container on this branch **g0.129-headerWindow**. **You can use the devcontainer approach OR the following commands:**
  ```
  cd ~/Dockers
  git clone https://github.com/TripalCultivate/TripalCultivate trpcultBase-PRNUM
  git checkout BRANCHNAME
  cd trpcultBase-PRNUM
  docker build --tag=trpcultivate-base:reviewPRNUM ./
  docker run --publish=80:80 -tid --name=basePRNUM --volume=`pwd`:/var/www/drupal/web/modules/contrib/TripalCultivate trpcultivate-base:reviewPRNUM
  ```

2. Extract and copy the importer plugin into **src/Plugin/TripalImporter/** directory.

[TestTripalImporter.php.zip](https://github.com/user-attachments/files/31744596/TestTripalImporter.php.zip)


3. Access the test importer and verify that with additional traits, the trait summary listing has a vertical scrollbar. Traits are contained in a window with vertical scrollbar while keeping the form height compact.

<img width="403" height="287" alt="Screenshot 2026-08-31 at 12 10 07 PM" src="https://github.com/user-attachments/assets/67e1b145-5261-4a1e-81f7-c744a5c31d11" />

<img width="1978" height="2567" alt="Screenshot 2026-09-02 at 09-03-11 Tripal Cultivate Test Importer Tripal Cultivate Docker" src="https://github.com/user-attachments/assets/0ef50010-cb02-4caa-aa19-7e66dc1c1675" />

4. Edit the importer plugin in **src/Plugin/TripalImporter/TestTripalImporter.php** and on line 112 rename $heaaders variable to $headers_2 and the $headers_x variable on line 86 to $headers.

6. Clear the cache (drush cr) and reload the importer form to show that with less traits, the window height will adjust to list the traits without the need for scrollbar.

